### PR TITLE
Remove submodule instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ See `.devcontainer/README.md` for more details about the Dev Container setup.
 1.  **Clone the repository:**
 
     ```bash
-    git clone git@github.com:jaspermayone/witcc-calendar-backend.git
+    git clone https://github.com/jaspermayone/witcc-calendar-backend.git
     cd witcc-calendar-backend
     ```
 


### PR DESCRIPTION
Removed instructions for using the submodule and streamlined the cloning process.

Solves #98