### PR TITLE
Fix button alignment on faculty directory pages

### DIFF
--- a/app/views/admin/faculties/directory_status.html.erb
+++ b/app/views/admin/faculties/directory_status.html.erb
@@ -6,6 +6,7 @@
         <%= button_to "Sync Now", sync_directory_admin_faculties_path,
             method: :post,
             class: "bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded text-sm cursor-pointer",
+            form: { class: "inline-flex" },
             data: {
               turbo_confirm: "This will sync all 800+ faculty/staff from the WIT directory. Continue?"
             } %>

--- a/app/views/admin/faculties/index.html.erb
+++ b/app/views/admin/faculties/index.html.erb
@@ -6,6 +6,7 @@
         <%= button_to "Sync Directory", sync_directory_admin_faculties_path,
             method: :post,
             class: "bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded text-sm cursor-pointer",
+            form: { class: "inline-flex" },
             data: {
               turbo_confirm: "This will sync all 800+ faculty/staff from the WIT directory. Continue?"
             } %>

--- a/app/views/admin/faculties/missing_rmp_ids.html.erb
+++ b/app/views/admin/faculties/missing_rmp_ids.html.erb
@@ -41,6 +41,7 @@
                 batch_auto_fill_admin_faculties_path,
                 method: :post,
                 class: "bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded text-sm cursor-pointer",
+                form: { class: "inline-flex" },
                 data: {
                   turbo_confirm: "This will queue background jobs to search Rate My Professor for all #{@faculties.total_count} faculty members. Continue?"
                 } %>
@@ -88,7 +89,8 @@
                       <%= button_to "Auto Search",
                           auto_fill_rmp_id_admin_faculty_path(faculty),
                           method: :post,
-                          class: "bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded text-xs cursor-pointer" %>
+                          class: "bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded text-xs cursor-pointer",
+                          form: { class: "inline-flex" } %>
                     <% end %>
                     <% if policy(faculty).search_rmp? %>
                       <%= link_to "Manual Search",

--- a/app/views/admin/faculties/search_rmp.html.erb
+++ b/app/views/admin/faculties/search_rmp.html.erb
@@ -128,6 +128,7 @@
                   assign_rmp_id_admin_faculty_path(@faculty, rmp_id: teacher["id"]),
                   method: :post,
                   class: "bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded text-sm cursor-pointer whitespace-nowrap",
+                  form: { class: "inline-flex" },
                   data: {
                     turbo_confirm: "Assign RMP ID '#{teacher['id']}' to #{@faculty.full_name}?"
                   } %>


### PR DESCRIPTION
## Summary
- Fix CSS alignment issues on faculty directory pages caused by `button_to` form wrappers breaking flex layouts
- Add `form: { class: "inline-flex" }` to all `button_to` elements in flex containers

Fixes #219