### PR TITLE
Hide events without location on admin events page

### DIFF
--- a/app/controllers/admin/university_calendar_events_controller.rb
+++ b/app/controllers/admin/university_calendar_events_controller.rb
@@ -7,6 +7,9 @@ module Admin
                                     .includes(:term)
                                     .order(start_time: :desc)
 
+      # By default, hide events without a location (unless explicitly showing all)
+      @university_calendar_events = @university_calendar_events.with_location unless params[:show_all] == "1"
+
       # Search filter
       if params[:search].present?
         @university_calendar_events = @university_calendar_events

--- a/app/models/university_calendar_event.rb
+++ b/app/models/university_calendar_event.rb
@@ -68,6 +68,8 @@ class UniversityCalendarEvent < ApplicationRecord
     where(start_time: start_date.beginning_of_day..end_date.end_of_day)
   }
   scope :by_categories, ->(categories) { where(category: categories) }
+  scope :with_location, -> { where.not(location: [nil, ""]) }
+  scope :without_location, -> { where(location: [nil, ""]) }
 
   # Get holidays within a date range (useful for schedule adjustments and EXDATE generation)
   # @param start_date [Date] The start of the date range

--- a/app/views/admin/university_calendar_events/index.html.erb
+++ b/app/views/admin/university_calendar_events/index.html.erb
@@ -44,8 +44,12 @@
           ),
           {},
           class: "glass-input px-4 py-2 border border-gray-300 rounded-md" %>
+      <label class="flex items-center gap-2 text-sm text-gray-700">
+        <%= f.check_box :show_all, { checked: params[:show_all] == "1" }, "1", "0" %>
+        Show events without location
+      </label>
       <%= f.submit "Filter", class: "glass-button px-6 py-2 rounded cursor-pointer" %>
-      <% if params[:search].present? || params[:category].present? %>
+      <% if params[:search].present? || params[:category].present? || params[:show_all] == "1" %>
         <%= link_to "Clear", admin_university_calendar_events_path, class: "glass-button px-6 py-2 rounded" %>
       <% end %>
     <% end %>

--- a/spec/models/university_calendar_event_spec.rb
+++ b/spec/models/university_calendar_event_spec.rb
@@ -141,6 +141,32 @@ RSpec.describe UniversityCalendarEvent, type: :model do
         expect(result).not_to include(campus)
       end
     end
+
+    describe ".with_location" do
+      it "returns events that have a location" do
+        with_location = create(:university_calendar_event, location: "Room 101")
+        without_location = create(:university_calendar_event, location: nil)
+        empty_location = create(:university_calendar_event, location: "")
+
+        result = described_class.with_location
+
+        expect(result).to include(with_location)
+        expect(result).not_to include(without_location, empty_location)
+      end
+    end
+
+    describe ".without_location" do
+      it "returns events that have no location" do
+        with_location = create(:university_calendar_event, location: "Room 101")
+        without_location = create(:university_calendar_event, location: nil)
+        empty_location = create(:university_calendar_event, location: "")
+
+        result = described_class.without_location
+
+        expect(result).to include(without_location, empty_location)
+        expect(result).not_to include(with_location)
+      end
+    end
   end
 
   describe ".holidays_between" do


### PR DESCRIPTION
## Summary
- Adds `with_location` and `without_location` scopes to UniversityCalendarEvent
- Filters admin university calendar events page to hide events without location by default
- Adds \"Show events without location\" checkbox filter to optionally display them

Fixes #218