### PR TITLE
fix: incorrect uni cal event parsing

### DIFF
--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -243,12 +243,7 @@ class CalendarsController < ApplicationController
 
       # Add holiday prefix to make it clear in calendar apps
       if event.category == "holiday"
-        # Only append "No Classes" if the summary doesn't already contain it
-        if event.summary.to_s.downcase.include?("no class")
-          e.summary = "🏫 #{event.summary}"
-        else
-          e.summary = "🏫 #{event.summary} - No Classes"
-        end
+        e.summary = event.formatted_holiday_summary
       else
         e.summary = event.summary
       end

--- a/app/models/concerns/course_schedule_syncable.rb
+++ b/app/models/concerns/course_schedule_syncable.rb
@@ -402,14 +402,8 @@ module CourseScheduleSyncable
 
     # Always include holidays (auto-sync for all users)
     UniversityCalendarEvent.holidays.upcoming.find_each do |event|
-      # Only append "No Classes" if the summary doesn't already contain it
-      holiday_summary = if event.summary.to_s.downcase.include?("no class")
-                          "🏫 #{event.summary}"
-                        else
-                          "🏫 #{event.summary} - No Classes"
-                        end
       events << {
-        summary: holiday_summary,
+        summary: event.formatted_holiday_summary,
         description: event.description,
         location: event.location,
         start_time: event.start_time,

--- a/app/models/university_calendar_event.rb
+++ b/app/models/university_calendar_event.rb
@@ -169,4 +169,16 @@ class UniversityCalendarEvent < ApplicationRecord
     ((end_time - start_time) / 1.hour).round(1)
   end
 
+  # Returns formatted summary for holiday events with school emoji prefix
+  # Only appends "No Classes" if the summary doesn't already contain it
+  # @return [String] The formatted holiday summary
+  def formatted_holiday_summary
+    # Use word boundary regex to avoid false positives like "classical" or "classroom"
+    if summary.to_s.match?(/\bno\s+class(es)?\b/i)
+      "🏫 #{summary}"
+    else
+      "🏫 #{summary} - No Classes"
+    end
+  end
+
 end

--- a/spec/models/university_calendar_event_spec.rb
+++ b/spec/models/university_calendar_event_spec.rb
@@ -298,4 +298,31 @@ RSpec.describe UniversityCalendarEvent, type: :model do
       expect(event.recurrence).to be_nil
     end
   end
+
+  describe "#formatted_holiday_summary" do
+    it "adds emoji prefix and 'No Classes' suffix for regular holidays" do
+      event = build(:university_calendar_event, :holiday, summary: "Labor Day")
+      expect(event.formatted_holiday_summary).to eq("🏫 Labor Day - No Classes")
+    end
+
+    it "adds only emoji prefix when summary already contains 'No Classes'" do
+      event = build(:university_calendar_event, :holiday, summary: "Thanksgiving Break - No Classes")
+      expect(event.formatted_holiday_summary).to eq("🏫 Thanksgiving Break - No Classes")
+    end
+
+    it "handles 'no class' (singular) in summary" do
+      event = build(:university_calendar_event, :holiday, summary: "Holiday - No Class")
+      expect(event.formatted_holiday_summary).to eq("🏫 Holiday - No Class")
+    end
+
+    it "uses word boundaries to avoid false positives like 'classical'" do
+      event = build(:university_calendar_event, :holiday, summary: "Classical Music Day")
+      expect(event.formatted_holiday_summary).to eq("🏫 Classical Music Day - No Classes")
+    end
+
+    it "is case insensitive when checking for 'no classes'" do
+      event = build(:university_calendar_event, :holiday, summary: "Holiday - NO CLASSES")
+      expect(event.formatted_holiday_summary).to eq("🏫 Holiday - NO CLASSES")
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Holidays with "no classes" in their name (e.g., "Thanksgiving Break - No Classes") were getting a duplicate suffix added ("🏫 Thanksgiving Break - No Classes - No Classes")
- Now checks if the summary already contains "no class" before appending the suffix

## Test plan
- [x] University calendar event model tests pass
- [x] Course schedule syncable tests pass
- [ ] Verify holiday events display correctly without duplication

Fixes #211