### PR TITLE
fix: normalize section_number spacing (1 A -> 1A)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -53,4 +53,12 @@ module ApplicationHelper
     match ? match[1] : subject
   end
 
+  # Normalize section number by removing spaces between digits and letters
+  # e.g., "1 A" -> "1A", "2 B" -> "2B"
+  def normalize_section_number(section)
+    return nil if section.blank?
+
+    section.strip.gsub(/(\d)\s+([A-Za-z])/, '\1\2').upcase
+  end
+
 end

--- a/app/jobs/course_data_sync_job.rb
+++ b/app/jobs/course_data_sync_job.rb
@@ -102,7 +102,7 @@ class CourseDataSyncJob < ApplicationJob
     fresh_credit_hours = fresh_data[:credit_hours]
     fresh_grade_mode = fresh_data[:grade_mode]&.strip
     fresh_subject = fresh_data[:subject]&.strip
-    fresh_section_number = fresh_data[:section_number]&.strip
+    fresh_section_number = normalize_section_number(fresh_data[:section_number])
     
     # Extract schedule type from format like "Lecture (LEC)"
     fresh_schedule_type = nil
@@ -163,7 +163,7 @@ class CourseDataSyncJob < ApplicationJob
     fresh_credit_hours = fresh_data[:credit_hours]
     fresh_grade_mode = fresh_data[:grade_mode]&.strip
     fresh_subject = fresh_data[:subject]&.strip
-    fresh_section_number = fresh_data[:section_number]&.strip
+    fresh_section_number = normalize_section_number(fresh_data[:section_number])
     
     # Extract schedule type
     fresh_schedule_type = nil

--- a/app/services/catalog_import_service.rb
+++ b/app/services/catalog_import_service.rb
@@ -123,7 +123,7 @@ class CatalogImportService < ApplicationService
       c.subject = course_data["subject"] || course_data["subjectCode"]
       c.course_number = course_data["courseNumber"]
       c.schedule_type = schedule_type_match ? schedule_type_match[1] : nil
-      c.section_number = course_data["sequenceNumber"] || course_data["sectionNumber"]
+      c.section_number = normalize_section_number(course_data["sequenceNumber"] || course_data["sectionNumber"])
 
       # LeopardWeb shows total course credit hours for all sections (lecture + lab)
       # Labs are typically 0-credit companion sections, so override for LAB schedule type

--- a/app/services/course_processor_service.rb
+++ b/app/services/course_processor_service.rb
@@ -135,7 +135,7 @@ class CourseProcessorService < ApplicationService
         c.subject = detailed_course_info[:subject]
         c.course_number = course_data[:courseNumber]
         c.schedule_type = schedule_type_match ? schedule_type_match[1] : nil
-        c.section_number = detailed_course_info[:section_number]
+        c.section_number = normalize_section_number(detailed_course_info[:section_number])
 
         # LeopardWeb shows total course credit hours for all sections (lecture + lab)
         # Labs are typically 0-credit companion sections, so override for LAB schedule type

--- a/lib/tasks/fix_roman_numerals.rake
+++ b/lib/tasks/fix_roman_numerals.rake
@@ -1,66 +1,123 @@
 namespace :courses do
-  desc "Fix Roman numerals in course titles (e.g., 'Computer Science Ii' -> 'Computer Science II')"
-  task fix_roman_numerals: :environment do
+  desc "Fix course formatting: Roman numerals in titles and spacing in section numbers"
+  task fix_formatting: :environment do
     include ApplicationHelper
 
-    puts "Finding courses with incorrect Roman numerals..."
-    
-    # Find courses where the title would change when passed through titleize_with_roman_numerals
-    # This catches any case where Roman numerals aren't properly capitalized
+    puts "Finding courses with formatting issues..."
+
+    # Find courses where title or section_number would change when normalized
     courses_to_fix = Course.where.not(title: nil).select do |course|
-      original_title = course.title
-      corrected_title = titleize_with_roman_numerals(original_title)
-      original_title != corrected_title
+      title_needs_fix = course.title != titleize_with_roman_numerals(course.title)
+      section_needs_fix = course.section_number.present? &&
+                          course.section_number != normalize_section_number(course.section_number)
+      title_needs_fix || section_needs_fix
     end
-    
-    puts "Found #{courses_to_fix.count} courses with incorrect Roman numerals"
-    
+
+    puts "Found #{courses_to_fix.count} courses with formatting issues"
+
     if courses_to_fix.count == 0
       puts "No courses need fixing!"
       next
     end
-    
+
     puts "\nCourses that will be updated:"
     courses_to_fix.each do |course|
+      changes = []
+
       old_title = course.title
       new_title = titleize_with_roman_numerals(old_title)
-      puts "CRN #{course.crn}: '#{old_title}' -> '#{new_title}'"
+      changes << "title: '#{old_title}' -> '#{new_title}'" if old_title != new_title
+
+      old_section = course.section_number
+      new_section = normalize_section_number(old_section)
+      changes << "section: '#{old_section}' -> '#{new_section}'" if old_section != new_section
+
+      puts "CRN #{course.crn}: #{changes.join(', ')}"
     end
-    
+
     print "\nProceed with updating #{courses_to_fix.count} courses? (y/N): "
     response = STDIN.gets.chomp.downcase
-    
+
     unless response == 'y' || response == 'yes'
       puts "Cancelled."
       next
     end
-    
+
     puts "\nUpdating courses..."
     updated_count = 0
     failed_count = 0
-    
+    affected_course_ids = []
+
     courses_to_fix.each do |course|
       begin
+        updates = {}
+
         old_title = course.title
         new_title = titleize_with_roman_numerals(old_title)
-        
-        # Only update if the title actually changes
-        if old_title != new_title
-          course.update!(title: new_title)
+        updates[:title] = new_title if old_title != new_title
+
+        old_section = course.section_number
+        new_section = normalize_section_number(old_section)
+        updates[:section_number] = new_section if old_section != new_section
+
+        if updates.any?
+          course.update!(updates)
           updated_count += 1
-          puts "✓ CRN #{course.crn}: Updated to '#{new_title}'"
+          affected_course_ids << course.id
+          puts "✓ CRN #{course.crn}: Updated #{updates.keys.join(', ')}"
         end
       rescue => e
         failed_count += 1
         puts "✗ CRN #{course.crn}: Failed - #{e.message}"
       end
     end
-    
-    puts "\n" + "="*50
-    puts "SUMMARY:"
+
+    puts "\n" + "=" * 50
+    puts "COURSE UPDATE SUMMARY:"
     puts "Total courses processed: #{courses_to_fix.count}"
     puts "Successfully updated: #{updated_count}"
     puts "Failed: #{failed_count}"
-    puts "="*50
+    puts "=" * 50
+
+    # Queue calendar syncs for affected users
+    if updated_count > 0
+      print "\nQueue calendar syncs for affected users? (y/N): "
+      sync_response = STDIN.gets.chomp.downcase
+
+      if sync_response == 'y' || sync_response == 'yes'
+        # Find users enrolled in the affected courses
+        affected_user_ids = Enrollment.where(course_id: affected_course_ids)
+                                      .distinct
+                                      .pluck(:user_id)
+
+        # Also find users via meeting times (for Google Calendar events)
+        meeting_time_ids = MeetingTime.where(course_id: affected_course_ids).pluck(:id)
+        calendar_user_ids = GoogleCalendarEvent.where(meeting_time_id: meeting_time_ids)
+                                               .joins(google_calendar: :oauth_credential)
+                                               .pluck("oauth_credentials.user_id")
+                                               .uniq
+
+        all_user_ids = (affected_user_ids + calendar_user_ids).uniq
+
+        puts "\nFound #{all_user_ids.count} users with affected courses"
+
+        queued_count = 0
+        all_user_ids.each do |user_id|
+          user = User.find_by(id: user_id)
+          next unless user&.google_credential&.google_calendar
+
+          GoogleCalendarSyncJob.perform_later(user, force: true)
+          queued_count += 1
+        end
+
+        puts "Queued #{queued_count} calendar sync jobs"
+      end
+    end
+
+    puts "\nDone!"
   end
+
+  # Keep old task name as alias for backwards compatibility
+  desc "Alias for fix_formatting (deprecated)"
+  task fix_roman_numerals: :fix_formatting
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -7,10 +7,44 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.titleize_with_roman_numerals('Physics 1 B')).to eq('Physics 1B')
       expect(helper.titleize_with_roman_numerals('chemistry 3 c')).to eq('Chemistry 3C')
     end
-    
+
     it 'preserves Roman numerals' do
       expect(helper.titleize_with_roman_numerals('calculus ii')).to eq('Calculus II')
       expect(helper.titleize_with_roman_numerals('physics iv lab')).to eq('Physics IV Lab')
+    end
+  end
+
+  describe '#normalize_section_number' do
+    it 'removes spaces between digits and letters' do
+      expect(helper.normalize_section_number('1 A')).to eq('1A')
+      expect(helper.normalize_section_number('2 B')).to eq('2B')
+      expect(helper.normalize_section_number('10 C')).to eq('10C')
+    end
+
+    it 'uppercases letters' do
+      expect(helper.normalize_section_number('1a')).to eq('1A')
+      expect(helper.normalize_section_number('2b')).to eq('2B')
+    end
+
+    it 'strips leading and trailing whitespace' do
+      expect(helper.normalize_section_number('  1A  ')).to eq('1A')
+      expect(helper.normalize_section_number(' 2 B ')).to eq('2B')
+    end
+
+    it 'handles already correct section numbers' do
+      expect(helper.normalize_section_number('1A')).to eq('1A')
+      expect(helper.normalize_section_number('2B')).to eq('2B')
+    end
+
+    it 'returns nil for blank input' do
+      expect(helper.normalize_section_number(nil)).to be_nil
+      expect(helper.normalize_section_number('')).to be_nil
+      expect(helper.normalize_section_number('   ')).to be_nil
+    end
+
+    it 'handles numeric-only section numbers' do
+      expect(helper.normalize_section_number('001')).to eq('001')
+      expect(helper.normalize_section_number('123')).to eq('123')
     end
   end
 end

--- a/spec/jobs/course_data_sync_job_spec.rb
+++ b/spec/jobs/course_data_sync_job_spec.rb
@@ -143,6 +143,22 @@ RSpec.describe CourseDataSyncJob, type: :job do
 
       expect(course.reload.title).to eq("Calculus 2A")
     end
+
+    it "normalizes section numbers by removing spaces" do
+      data_with_spaced_section = { section_number: "1 A" }
+
+      job.send(:update_course_from_fresh_data, course, data_with_spaced_section, term.uid)
+
+      expect(course.reload.section_number).to eq("1A")
+    end
+
+    it "uppercases section number letters" do
+      data_with_lowercase_section = { section_number: "2b" }
+
+      job.send(:update_course_from_fresh_data, course, data_with_lowercase_section, term.uid)
+
+      expect(course.reload.section_number).to eq("2B")
+    end
   end
 
   describe "#meeting_times_changed?" do


### PR DESCRIPTION
## Summary
- Fixes root cause of 1 A vs 1A spacing issue in section numbers
- LeopardWeb returns section numbers with internal spaces that were not being cleaned
- Adds normalize_section_number helper and applies it across all import paths
- Updates rake task to fix existing data and auto-queue calendar syncs

## Changes
- app/helpers/application_helper.rb: Add normalize_section_number helper
- app/jobs/course_data_sync_job.rb: Use new helper for section_number
- app/services/course_processor_service.rb: Use new helper
- app/services/catalog_import_service.rb: Use new helper
- lib/tasks/fix_roman_numerals.rake: Renamed to courses:fix_formatting, fixes both title and section_number, prompts to queue calendar syncs

## Test plan
- [x] Helper tests pass for normalize_section_number
- [x] CourseDataSyncJob tests pass including new section normalization tests
- [ ] Run rails courses:fix_formatting in production to fix existing data

Fixes #208