### PR TITLE
Add needs_reauth to oauth_credentials response

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -325,7 +325,9 @@ module Api
           provider: credential.provider,
           has_calendar: credential.google_calendar.present?,
           calendar_id: credential.google_calendar&.google_calendar_id,
-          created_at: credential.created_at
+          created_at: credential.created_at,
+          needs_reauth: credential.needs_reauth?,
+          token_revoked: credential.token_revoked?
         }
       end
 

--- a/spec/factories/oauth_credentials.rb
+++ b/spec/factories/oauth_credentials.rb
@@ -46,5 +46,13 @@ FactoryBot.define do
     trait :expired do
       token_expires_at { 1.hour.ago }
     end
+
+    trait :revoked do
+      metadata { { "token_revoked" => true } }
+    end
+
+    trait :without_refresh_token do
+      refresh_token { nil }
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Returns `needs_reauth` and `token_revoked` fields in the `list_oauth_credentials` API response
- Allows the extension to detect when a user's OAuth token is expired/revoked and prompt re-authentication

## Test plan
- [ ] Verify `needs_reauth` is false for healthy credentials
- [ ] Verify `needs_reauth` is true when token is revoked
- [ ] Verify `needs_reauth` is true when refresh_token is missing