### PR TITLE
Fix Disable Notifications button to work as DND toggle

### DIFF
--- a/app/controllers/api/event_preferences_controller.rb
+++ b/app/controllers/api/event_preferences_controller.rb
@@ -33,7 +33,8 @@ module Api
         resolved: resolved_prefs,
         sources: resolved_data[:sources],
         preview: preview,
-        templates: context
+        templates: context,
+        notifications_disabled: resolver.notifications_disabled?
       }
     end
 
@@ -73,7 +74,8 @@ module Api
           resolved: resolved_prefs,
           sources: resolved_data[:sources],
           preview: preview,
-          templates: context
+          templates: context,
+          notifications_disabled: fresh_resolver.notifications_disabled?
         }
       else
         render json: { errors: preference.errors.full_messages }, status: :unprocessable_content

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -253,8 +253,8 @@ module Api
         day_symbol = mt.day_of_week&.to_sym
         days[day_symbol] = true if day_symbol
 
-        # Resolve preferences for this meeting time
-        preferences = preference_resolver.resolve_for(mt)
+        # Resolve preferences for this meeting time (ignore DND for display purposes)
+        preferences = preference_resolver.resolve_actual_for(mt)
 
         # Build template context
         context = CalendarTemplateRenderer.build_context_from_meeting_time(mt)
@@ -521,7 +521,10 @@ module Api
         }
       end
 
-      render json: { classes: structured_data }, status: :ok
+      render json: {
+        classes: structured_data,
+        notifications_disabled: current_user.notifications_disabled?
+      }, status: :ok
     end
 
 


### PR DESCRIPTION
## Summary
- Fixes the "Disable Notifications" button to work as a proper DND toggle
- API now returns actual configured reminders even when DND is active
- Adds `notifications_disabled` flag to API responses so frontend can show reminders as "muted"
- Google Calendar sync still respects DND (no reminders synced when DND is on)

## Changes
- `PreferenceResolver.resolve_actual_for` - new method to get preferences without DND override
- `PreferenceResolver.resolve_with_sources` - now ignores DND for API display
- `PreferenceResolver.notifications_disabled?` - exposes DND state
- `EventPreferencesController` - includes `notifications_disabled` in response
- `UsersController` - includes `notifications_disabled` in events response

## Test plan
- [x] PreferenceResolver tests pass (38 examples)
- [x] Rubocop passes
- [ ] Verify API returns actual reminders when DND is on
- [ ] Verify frontend can display reminders as muted when DND is active

Fixes #215