### PR TITLE
Add embedding generation via OpenAI API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -133,6 +133,7 @@ gem "omniauth-google-oauth2", "~> 1.2", ">= 1.2.1"
 
 gem "pgvector"
 gem "neighbor"
+gem "ruby-openai", "~> 7.0"
 gem "log_bench"
 
 gem "kaminari", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,6 +178,7 @@ GEM
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
+    event_stream_parser (1.0.0)
     factory_bot (6.5.6)
       activesupport (>= 6.1.0)
     factory_bot_rails (6.5.1)
@@ -191,6 +192,8 @@ GEM
       logger
     faraday-follow_redirects (0.5.0)
       faraday (>= 1, < 3)
+    faraday-multipart (1.2.0)
+      multipart-post (~> 2.0)
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
     ffi (1.17.3-aarch64-linux-gnu)
@@ -382,6 +385,7 @@ GEM
     multi_json (1.19.1)
     multi_xml (0.8.1)
       bigdecimal (>= 3.1, < 5)
+    multipart-post (2.4.1)
     neighbor (0.6.0)
       activerecord (>= 7.1)
     net-http (0.9.1)
@@ -645,6 +649,10 @@ GEM
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
       rubocop-rspec (~> 3.5)
+    ruby-openai (7.4.0)
+      event_stream_parser (>= 0.3.0, < 2.0.0)
+      faraday (>= 1)
+      faraday-multipart (>= 1)
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     rubyzip (3.2.2)
@@ -838,6 +846,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec (~> 3.8)
   rubocop-rspec_rails (~> 2.32)
+  ruby-openai (~> 7.0)
   selenium-webdriver
   shoulda-matchers
   simplecov

--- a/app/jobs/generate_embedding_job.rb
+++ b/app/jobs/generate_embedding_job.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class GenerateEmbeddingJob < ApplicationJob
+  queue_as :default
+
+  # Retry on API errors with exponential backoff
+  retry_on EmbeddingService::ApiError, wait: :polynomially_longer, attempts: 5
+  retry_on Faraday::Error, wait: :polynomially_longer, attempts: 5
+
+  # Don't retry on configuration errors
+  discard_on EmbeddingService::ConfigurationError
+
+  # Generate embedding for a single record
+  # @param record_type [String] Class name of the record (e.g., "Course")
+  # @param record_id [Integer] ID of the record
+  def perform(record_type, record_id)
+    record = record_type.constantize.find_by(id: record_id)
+
+    unless record
+      Rails.logger.warn("[GenerateEmbeddingJob] Record not found: #{record_type}##{record_id}")
+      return
+    end
+
+    service = EmbeddingService.new
+    service.embed_record(record)
+  end
+
+end

--- a/app/models/concerns/embeddable.rb
+++ b/app/models/concerns/embeddable.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Concern for models that support vector embeddings
+# Include this in models that have an `embedding` column and `embedding_text` method
+#
+# Usage:
+#   class Course < ApplicationRecord
+#     include Embeddable
+#     # Define embedding_text method that returns text to embed
+#   end
+#
+module Embeddable
+  extend ActiveSupport::Concern
+
+  included do
+    # Automatically generate embedding when record is created or relevant fields change
+    after_commit :enqueue_embedding_generation, on: [:create, :update], if: :should_generate_embedding?
+
+    scope :with_embeddings, -> { where.not(embedding: nil) }
+    scope :without_embeddings, -> { where(embedding: nil) }
+  end
+
+  # Queue a job to generate embedding for this record
+  def enqueue_embedding_generation
+    GenerateEmbeddingJob.perform_later(self.class.name, id)
+  end
+
+  # Generate embedding synchronously (useful for console/testing)
+  def generate_embedding!
+    EmbeddingService.new.embed_record(self)
+  end
+
+  # Check if the embedding needs to be regenerated
+  def embedding_stale?
+    embedding.nil? || embedding_text_changed?
+  end
+
+  private
+
+  # Determine if we should generate a new embedding
+  # Override in model if you want custom logic
+  def should_generate_embedding?
+    return false unless respond_to?(:embedding_text)
+    return false if embedding_text.blank?
+
+    # Generate on create, or when embedding_text would have changed
+    embedding.nil? || embedding_text_fields_changed?
+  end
+
+  # Check if any fields that affect embedding_text have changed
+  # Models can override this for custom behavior
+  def embedding_text_fields_changed?
+    # Default: check if any saved changes exist that could affect embedding
+    # This is a conservative approach - models can override for precision
+    saved_changes.keys.any? { |key| key != "embedding" && key != "updated_at" }
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -33,6 +33,7 @@
 class Course < ApplicationRecord
   include CourseChangeTrackable
   include PublicIdentifiable
+  include Embeddable
 
   set_public_id_prefix :crs
 
@@ -52,8 +53,6 @@ class Course < ApplicationRecord
   after_destroy :update_term_dates
   # Update term dates when course dates change
   after_save :update_term_dates, if: -> { saved_change_to_start_date? || saved_change_to_end_date? }
-
-  scope :with_embeddings, -> { where.not(embedding: nil) }
 
   enum :schedule_type, {
     hybrid: "HYB",

--- a/app/services/embedding_service.rb
+++ b/app/services/embedding_service.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+class EmbeddingService
+  DEFAULT_MODEL = "text-embedding-3-small"
+  DIMENSIONS = 1536
+
+  class Error < StandardError; end
+  class ConfigurationError < Error; end
+  class ApiError < Error; end
+
+  def initialize(model: DEFAULT_MODEL)
+    @model = model
+    @client = build_client
+  end
+
+  # Generate embedding for a single text
+  # @param text [String] The text to embed
+  # @return [Array<Float>] The embedding vector (1536 dimensions)
+  def generate(text)
+    return nil if text.blank?
+
+    response = @client.embeddings(
+      parameters: {
+        model: @model,
+        input: text.truncate(8000), # OpenAI has token limits
+        dimensions: DIMENSIONS
+      }
+    )
+
+    response.dig("data", 0, "embedding")
+  rescue Faraday::Error => e
+    Rails.logger.error("[EmbeddingService] API request failed: #{e.message}")
+    raise ApiError, "Failed to generate embedding: #{e.message}"
+  end
+
+  # Generate embeddings for multiple texts in a single API call
+  # @param texts [Array<String>] Array of texts to embed
+  # @return [Array<Array<Float>>] Array of embedding vectors
+  def generate_batch(texts)
+    return [] if texts.blank?
+
+    # Filter out blank texts and track their indices
+    valid_texts = []
+    valid_indices = []
+
+    texts.each_with_index do |text, index|
+      next if text.blank?
+
+      valid_texts << text.truncate(8000)
+      valid_indices << index
+    end
+
+    return Array.new(texts.length) if valid_texts.empty?
+
+    response = @client.embeddings(
+      parameters: {
+        model: @model,
+        input: valid_texts,
+        dimensions: DIMENSIONS
+      }
+    )
+
+    # Build result array with nils for blank inputs
+    result = Array.new(texts.length)
+    response["data"].each do |item|
+      original_index = valid_indices[item["index"]]
+      result[original_index] = item["embedding"]
+    end
+
+    result
+  rescue Faraday::Error => e
+    Rails.logger.error("[EmbeddingService] Batch API request failed: #{e.message}")
+    raise ApiError, "Failed to generate batch embeddings: #{e.message}"
+  end
+
+  # Generate and save embedding for a record
+  # @param record [ApplicationRecord] Record with embedding column and embedding_text method
+  # @return [Boolean] Whether the embedding was saved successfully
+  def embed_record(record)
+    unless record.respond_to?(:embedding_text)
+      Rails.logger.warn("[EmbeddingService] Record #{record.class.name}##{record.id} does not respond to embedding_text")
+      return false
+    end
+
+    text = record.embedding_text
+    return false if text.blank?
+
+    embedding = generate(text)
+    return false if embedding.nil?
+
+    # rubocop:disable Rails/SkipsModelValidations -- Intentionally skip callbacks to avoid infinite loops
+    record.update_column(:embedding, embedding)
+    # rubocop:enable Rails/SkipsModelValidations
+    Rails.logger.info("[EmbeddingService] Generated embedding for #{record.class.name}##{record.id}")
+    true
+  rescue ApiError => e
+    Rails.logger.error("[EmbeddingService] Failed to embed #{record.class.name}##{record.id}: #{e.message}")
+    false
+  end
+
+  # Generate and save embeddings for multiple records
+  # @param records [Array<ApplicationRecord>] Records with embedding column and embedding_text method
+  # @return [Integer] Number of records successfully embedded
+  def embed_records(records)
+    return 0 if records.empty?
+
+    texts = records.map do |record|
+      record.respond_to?(:embedding_text) ? record.embedding_text : nil
+    end
+
+    embeddings = generate_batch(texts)
+
+    success_count = 0
+    records.each_with_index do |record, index|
+      embedding = embeddings[index]
+      next if embedding.nil?
+
+      # rubocop:disable Rails/SkipsModelValidations -- Intentionally skip callbacks to avoid infinite loops
+      record.update_column(:embedding, embedding)
+      # rubocop:enable Rails/SkipsModelValidations
+      success_count += 1
+    end
+
+    Rails.logger.info("[EmbeddingService] Generated #{success_count}/#{records.length} embeddings for #{records.first.class.name}")
+    success_count
+  rescue ApiError => e
+    Rails.logger.error("[EmbeddingService] Batch embedding failed: #{e.message}")
+    0
+  end
+
+  private
+
+  def build_client
+    api_key = Rails.application.credentials.dig(:openai, :api_key) || ENV.fetch("OPENAI_API_KEY", nil)
+
+    if api_key.blank?
+      raise ConfigurationError, "OpenAI API key not configured. Set credentials.openai.api_key or OPENAI_API_KEY env var."
+    end
+
+    OpenAI::Client.new(access_token: api_key)
+  end
+
+end

--- a/lib/tasks/embeddings.rake
+++ b/lib/tasks/embeddings.rake
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+namespace :embeddings do
+  desc "Generate embeddings for all records missing them"
+  task backfill: :environment do
+    puts "Starting embedding backfill..."
+
+    models = [Course, Faculty, RmpRating]
+
+    models.each do |model|
+      count = model.without_embeddings.count
+      puts "\n#{model.name}: #{count} records without embeddings"
+
+      next if count.zero?
+
+      model.without_embeddings.find_each do |record|
+        GenerateEmbeddingJob.perform_later(model.name, record.id)
+      end
+
+      puts "  Queued #{count} jobs for #{model.name}"
+    end
+
+    puts "\nBackfill jobs queued! Run `bin/rails solid_queue:start` to process them."
+  end
+
+  desc "Generate embeddings synchronously (useful for small datasets or testing)"
+  task backfill_sync: :environment do
+    puts "Starting synchronous embedding backfill..."
+
+    service = EmbeddingService.new
+    models = [Course, Faculty, RmpRating]
+
+    models.each do |model|
+      records = model.without_embeddings
+      count = records.count
+      puts "\n#{model.name}: #{count} records without embeddings"
+
+      next if count.zero?
+
+      success = 0
+      records.find_each.with_index do |record, index|
+        if service.embed_record(record)
+          success += 1
+        end
+
+        # Progress indicator
+        print "." if (index + 1) % 10 == 0
+        print " #{index + 1}/#{count}" if (index + 1) % 100 == 0
+      end
+
+      puts "\n  Generated #{success}/#{count} embeddings for #{model.name}"
+    end
+
+    puts "\nBackfill complete!"
+  end
+
+  desc "Generate embeddings for a specific model"
+  task :backfill_model, [:model_name] => :environment do |_t, args|
+    model_name = args[:model_name]
+
+    if model_name.blank?
+      puts "Usage: rails embeddings:backfill_model[ModelName]"
+      puts "Available models: Course, Faculty, RmpRating"
+      exit 1
+    end
+
+    begin
+      model = model_name.constantize
+    rescue NameError
+      puts "Unknown model: #{model_name}"
+      exit 1
+    end
+
+    unless model.column_names.include?("embedding")
+      puts "Model #{model_name} does not have an embedding column"
+      exit 1
+    end
+
+    count = model.without_embeddings.count
+    puts "#{model_name}: #{count} records without embeddings"
+
+    if count.zero?
+      puts "Nothing to do!"
+      exit 0
+    end
+
+    model.without_embeddings.find_each do |record|
+      GenerateEmbeddingJob.perform_later(model_name, record.id)
+    end
+
+    puts "Queued #{count} jobs for #{model_name}"
+    puts "Run `bin/rails solid_queue:start` to process them."
+  end
+
+  desc "Show embedding statistics"
+  task stats: :environment do
+    puts "Embedding Statistics"
+    puts "=" * 40
+
+    models = [Course, Faculty, RmpRating]
+
+    models.each do |model|
+      total = model.count
+      with_embeddings = model.with_embeddings.count
+      without_embeddings = model.without_embeddings.count
+      percentage = total.positive? ? (with_embeddings.to_f / total * 100).round(1) : 0
+
+      puts "\n#{model.name}:"
+      puts "  Total:             #{total}"
+      puts "  With embeddings:   #{with_embeddings} (#{percentage}%)"
+      puts "  Without embeddings: #{without_embeddings}"
+    end
+  end
+
+  desc "Clear all embeddings (use with caution!)"
+  task clear: :environment do
+    puts "WARNING: This will clear all embeddings from the database!"
+    print "Type 'yes' to continue: "
+
+    confirmation = $stdin.gets.chomp
+    unless confirmation == "yes"
+      puts "Aborted."
+      exit 1
+    end
+
+    models = [Course, Faculty, RmpRating]
+
+    models.each do |model|
+      count = model.with_embeddings.count
+      # rubocop:disable Rails/SkipsModelValidations -- Bulk clear for efficiency
+      model.with_embeddings.update_all(embedding: nil)
+      # rubocop:enable Rails/SkipsModelValidations
+      puts "Cleared #{count} embeddings from #{model.name}"
+    end
+
+    puts "Done!"
+  end
+end

--- a/spec/jobs/generate_embedding_job_spec.rb
+++ b/spec/jobs/generate_embedding_job_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe GenerateEmbeddingJob do
+  let(:service) { instance_double(EmbeddingService) }
+
+  before do
+    allow(EmbeddingService).to receive(:new).and_return(service)
+  end
+
+  describe "#perform" do
+    context "with Course" do
+      let(:course) { create(:course) }
+
+      it "generates embedding for the record" do
+        allow(service).to receive(:embed_record).and_return(true)
+
+        described_class.perform_now("Course", course.id)
+
+        expect(service).to have_received(:embed_record).with(course)
+      end
+
+      it "handles non-existent record gracefully" do
+        expect {
+          described_class.perform_now("Course", 999_999)
+        }.not_to raise_error
+      end
+    end
+
+    context "with Faculty" do
+      let(:faculty) { create(:faculty) }
+
+      it "generates embedding for the record" do
+        allow(service).to receive(:embed_record).and_return(true)
+
+        described_class.perform_now("Faculty", faculty.id)
+
+        expect(service).to have_received(:embed_record).with(faculty)
+      end
+    end
+
+    context "with RmpRating" do
+      let(:faculty) { create(:faculty) }
+      let(:rmp_rating) { create(:rmp_rating, faculty: faculty) }
+
+      it "generates embedding for the record" do
+        allow(service).to receive(:embed_record).and_return(true)
+
+        described_class.perform_now("RmpRating", rmp_rating.id)
+
+        expect(service).to have_received(:embed_record).with(rmp_rating)
+      end
+    end
+  end
+
+  describe "error handling" do
+    let(:course) { create(:course) }
+
+    it "logs warning when record is not found" do
+      allow(Rails.logger).to receive(:warn)
+
+      described_class.perform_now("Course", 999_999)
+
+      expect(Rails.logger).to have_received(:warn).with(/Record not found/)
+    end
+  end
+end

--- a/spec/services/embedding_service_spec.rb
+++ b/spec/services/embedding_service_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EmbeddingService do
+  let(:api_key) { "test-api-key" }
+  let(:service) { described_class.new }
+  let(:fake_embedding) { Array.new(1536) { rand(-1.0..1.0) } }
+
+  before do
+    allow(Rails.application.credentials).to receive(:dig).with(:openai, :api_key).and_return(api_key)
+  end
+
+  describe "#initialize" do
+    it "raises ConfigurationError when API key is missing" do
+      allow(Rails.application.credentials).to receive(:dig).with(:openai, :api_key).and_return(nil)
+      allow(ENV).to receive(:[]).with("OPENAI_API_KEY").and_return(nil)
+
+      expect { described_class.new }.to raise_error(EmbeddingService::ConfigurationError)
+    end
+
+    it "uses ENV variable when credentials are not set" do
+      allow(Rails.application.credentials).to receive(:dig).with(:openai, :api_key).and_return(nil)
+      allow(ENV).to receive(:fetch).with("OPENAI_API_KEY", nil).and_return("env-api-key")
+
+      expect { described_class.new }.not_to raise_error
+    end
+  end
+
+  describe "#generate" do
+    let(:client) { instance_double(OpenAI::Client) }
+
+    before do
+      allow(OpenAI::Client).to receive(:new).and_return(client)
+    end
+
+    it "returns nil for blank text" do
+      expect(service.generate(nil)).to be_nil
+      expect(service.generate("")).to be_nil
+      expect(service.generate("   ")).to be_nil
+    end
+
+    it "generates embedding for valid text" do
+      allow(client).to receive(:embeddings).and_return({
+                                                         "data" => [{ "embedding" => fake_embedding }]
+                                                       })
+
+      result = service.generate("Test text")
+
+      expect(result).to eq(fake_embedding)
+      expect(result.length).to eq(1536)
+    end
+
+    it "truncates long text" do
+      allow(client).to receive(:embeddings).and_return({
+                                                         "data" => [{ "embedding" => fake_embedding }]
+                                                       })
+
+      long_text = "a" * 10_000
+      service.generate(long_text)
+
+      expect(client).to have_received(:embeddings) do |args|
+        expect(args[:parameters][:input].length).to be <= 8003 # 8000 + "..."
+      end
+    end
+
+    it "raises ApiError on API failure" do
+      allow(client).to receive(:embeddings).and_raise(Faraday::Error.new("Connection failed"))
+
+      expect { service.generate("Test") }.to raise_error(EmbeddingService::ApiError)
+    end
+  end
+
+  describe "#generate_batch" do
+    let(:client) { instance_double(OpenAI::Client) }
+
+    before do
+      allow(OpenAI::Client).to receive(:new).and_return(client)
+    end
+
+    it "returns empty array for empty input" do
+      expect(service.generate_batch([])).to eq([])
+    end
+
+    # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+    it "handles array with some blank texts" do
+      allow(client).to receive(:embeddings).and_return({
+                                                         "data" => [
+                                                           { "index" => 0, "embedding" => fake_embedding },
+                                                           { "index" => 1, "embedding" => fake_embedding }
+                                                         ]
+                                                       })
+
+      result = service.generate_batch(["text1", nil, "text2", ""])
+
+      expect(result[0]).to eq(fake_embedding)
+      expect(result[1]).to be_nil
+      expect(result[2]).to eq(fake_embedding)
+      expect(result[3]).to be_nil
+    end
+    # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations
+  end
+
+  describe "#embed_record" do
+    let(:client) { instance_double(OpenAI::Client) }
+    let(:course) { create(:course, title: "Test Course", subject: "Computer Science (COMP)") }
+
+    before do
+      allow(OpenAI::Client).to receive(:new).and_return(client)
+      allow(client).to receive(:embeddings).and_return({
+                                                         "data" => [{ "embedding" => fake_embedding }]
+                                                       })
+    end
+
+    # rubocop:disable RSpec/MultipleExpectations
+    it "generates and saves embedding for a record" do
+      expect(course.embedding).to be_nil
+
+      result = service.embed_record(course)
+
+      expect(result).to be true
+      # pgvector stores floats with reduced precision, so we compare lengths
+      expect(course.reload.embedding.length).to eq(fake_embedding.length)
+      expect(course.reload.embedding).to be_present
+    end
+    # rubocop:enable RSpec/MultipleExpectations
+
+    it "returns false for record without embedding_text method" do
+      record = instance_double("Record", id: 1) # rubocop:disable RSpec/VerifiedDoubleReference
+      allow(record).to receive(:respond_to?).with(:embedding_text).and_return(false)
+
+      expect(service.embed_record(record)).to be false
+    end
+
+    it "returns false when embedding_text is blank" do
+      allow(course).to receive(:embedding_text).and_return("")
+
+      expect(service.embed_record(course)).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `EmbeddingService` using OpenAI's `text-embedding-3-small` model (1536 dimensions)
- Add `GenerateEmbeddingJob` for async embedding generation with retry logic
- Add `Embeddable` concern with after_commit callbacks to trigger embedding on create/update
- Add `embedding_text` methods to `Faculty` and `RmpRating` models
- Add rake tasks (`embeddings:backfill`, `embeddings:stats`, `embeddings:clear`)

## Test plan
- [x] Unit tests for EmbeddingService
- [x] Unit tests for GenerateEmbeddingJob
- [x] All 16 tests passing
- [ ] Manual test: Run `rails embeddings:stats` to check current state
- [ ] Manual test: Run `rails embeddings:backfill` to queue embedding jobs

Closes #251