### PR TITLE
Implement field-level user edit tracking for Google Calendar sync

### DIFF
--- a/spec/models/google_calendar_event_spec.rb
+++ b/spec/models/google_calendar_event_spec.rb
@@ -13,6 +13,7 @@
 #  recurrence                   :text
 #  start_time                   :datetime
 #  summary                      :string
+#  user_edited_fields           :text
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  final_exam_id                :bigint
@@ -270,6 +271,115 @@ RSpec.describe GoogleCalendarEvent do
     it "returns false when last_synced_at is within threshold" do
       event = build(:google_calendar_event, last_synced_at: 30.minutes.ago)
       expect(event.needs_sync?(1.hour)).to be false
+    end
+  end
+
+  describe "#user_edited?" do
+    it "returns false when user_edited_fields is nil" do
+      event = build(:google_calendar_event, user_edited_fields: nil)
+      expect(event.user_edited?).to be false
+    end
+
+    it "returns false when user_edited_fields is empty" do
+      event = build(:google_calendar_event, user_edited_fields: [])
+      expect(event.user_edited?).to be false
+    end
+
+    it "returns true when user_edited_fields has values" do
+      event = build(:google_calendar_event, user_edited_fields: %w[summary])
+      expect(event.user_edited?).to be true
+    end
+  end
+
+  describe "#field_edited?" do
+    let(:event) { build(:google_calendar_event, user_edited_fields: %w[summary location]) }
+
+    it "returns true for edited fields" do
+      expect(event.field_edited?(:summary)).to be true
+      expect(event.field_edited?("location")).to be true
+    end
+
+    it "returns false for non-edited fields" do
+      expect(event.field_edited?(:description)).to be false
+      expect(event.field_edited?("start_time")).to be false
+    end
+
+    it "returns false when user_edited_fields is nil" do
+      event = build(:google_calendar_event, user_edited_fields: nil)
+      expect(event).not_to be_field_edited(:summary)
+    end
+  end
+
+  describe "#mark_fields_edited!" do
+    let(:event) { create(:google_calendar_event, user_edited_fields: nil) }
+
+    it "marks a single field as edited" do
+      event.mark_fields_edited!(:summary)
+      expect(event.reload.user_edited_fields).to eq(%w[summary])
+    end
+
+    it "marks multiple fields as edited" do
+      event.mark_fields_edited!(%w[summary location])
+      expect(event.reload.user_edited_fields).to match_array(%w[summary location])
+    end
+
+    it "accumulates edited fields" do
+      event.mark_fields_edited!(:summary)
+      event.mark_fields_edited!(:location)
+      expect(event.reload.user_edited_fields).to match_array(%w[summary location])
+    end
+
+    it "does not duplicate fields" do
+      event.mark_fields_edited!(:summary)
+      event.mark_fields_edited!(:summary)
+      expect(event.reload.user_edited_fields).to eq(%w[summary])
+    end
+
+    it "only tracks valid fields" do
+      event.mark_fields_edited!(%w[summary invalid_field location])
+      expect(event.reload.user_edited_fields).to match_array(%w[summary location])
+    end
+  end
+
+  describe "#clear_edited_fields!" do
+    let(:event) { create(:google_calendar_event, user_edited_fields: %w[summary location description]) }
+
+    it "clears all fields when called without arguments" do
+      event.clear_edited_fields!
+      expect(event.reload.user_edited_fields).to be_nil
+    end
+
+    it "clears specific fields when called with arguments" do
+      event.clear_edited_fields!(:summary)
+      expect(event.reload.user_edited_fields).to match_array(%w[location description])
+    end
+
+    it "clears multiple specific fields" do
+      event.clear_edited_fields!(%w[summary location])
+      expect(event.reload.user_edited_fields).to eq(%w[description])
+    end
+
+    it "sets to nil when all fields are cleared" do
+      event.clear_edited_fields!(%w[summary location description])
+      expect(event.reload.user_edited_fields).to be_nil
+    end
+  end
+
+  describe ".user_edited scope" do
+    let!(:edited_event) { create(:google_calendar_event, user_edited_fields: %w[summary]) }
+    let!(:unedited_event) { create(:google_calendar_event, user_edited_fields: nil) }
+
+    it "returns only user-edited events" do
+      expect(described_class.user_edited).to contain_exactly(edited_event)
+    end
+  end
+
+  describe ".not_user_edited scope" do
+    let!(:edited_event) { create(:google_calendar_event, user_edited_fields: %w[summary]) }
+    let!(:unedited_event) { create(:google_calendar_event, user_edited_fields: nil) }
+
+    it "returns only non-user-edited events" do
+      expect(described_class.not_user_edited).to contain_exactly(unedited_event)
     end
   end
 end


### PR DESCRIPTION
## Summary
- Implements field-level user edit detection and preservation for Google Calendar events
- Tracks which specific fields users edited (summary, location, description, start_time, end_time)
- Merges user edits with system updates: preserves user-edited fields while applying system changes to non-edited fields
- Force sync (`force: true`) clears tracked edits and applies all system changes

## Changes
- **Migration**: Adds `user_edited_fields` (text/JSON) column to store array of edited field names
- **Model**: New methods for field-level tracking (`user_edited?`, `field_edited?`, `mark_fields_edited!`, `clear_edited_fields!`)
- **Service**: Field-level merging in `update_event_in_calendar` - detects edits, merges values, tracks for future syncs

## Test plan
- [x] Model specs for field-level tracking methods
- [x] Service specs for field-level merging behavior
- [x] All 90 related specs pass

Closes #256