### PR TITLE
fix: correct Stimulus target syntax for command palette

### DIFF
--- a/app/views/shared/_command_palette.html.erb
+++ b/app/views/shared/_command_palette.html.erb
@@ -1,6 +1,6 @@
 <!-- Command Palette Modal -->
-<div data-controller="command-palette" 
-     data-command-palette-modal-target="modal"
+<div data-controller="command-palette"
+     data-command-palette-target="modal"
      data-action="click->command-palette#closeOnBackdrop"
      class="fixed inset-0 bg-black bg-opacity-50 flex items-start justify-center pt-[20vh] z-50 hidden">
   


### PR DESCRIPTION
## Summary
- Fixes typo in command palette Stimulus target attribute
- `data-command-palette-modal-target="modal"` → `data-command-palette-target="modal"`

## Test plan
- [ ] Press Cmd+K (or Ctrl+K) in admin panel
- [ ] Verify command palette opens
- [ ] Verify filtering and navigation work
- [ ] Verify clicking backdrop or pressing Escape closes it

Closes #273