### PR TITLE
Fix DND toggle not removing notifications from Google Calendar

### DIFF
--- a/app/services/google_calendar_service.rb
+++ b/app/services/google_calendar_service.rb
@@ -1038,8 +1038,8 @@ class GoogleCalendarService
       event_data[:location] = renderer.render(prefs[:location_template], context)
     end
 
-    # Apply reminder settings
-    event_data[:reminder_settings] = prefs[:reminder_settings] if prefs[:reminder_settings].present?
+    # Apply reminder settings (even if empty array - represents "no reminders")
+    event_data[:reminder_settings] = prefs[:reminder_settings] unless prefs[:reminder_settings].nil?
 
     # Apply color - convert hex codes to numeric IDs if needed
     if prefs[:color_id].present?


### PR DESCRIPTION
## Summary
Fixes the DND (Do Not Disturb) toggle bug where notifications were not being removed from Google Calendar when DND mode was enabled.

## Root Cause
The bug was in `GoogleCalendarService#apply_preferences_to_event` at line 1042:
```ruby
event_data[:reminder_settings] = prefs[:reminder_settings] if prefs[:reminder_settings].present?
```

When DND is enabled:
1. `PreferenceResolver#resolve_for` correctly returns `[]` (empty array) for reminder_settings
2. However, `[].present?` evaluates to `false` in Ruby
3. So the condition fails and reminder_settings are NOT applied to the event data
4. The old reminders remain in Google Calendar

## The Fix
Changed the condition from `.present?` to explicitly check for `nil`:
```ruby
event_data[:reminder_settings] = prefs[:reminder_settings] unless prefs[:reminder_settings].nil?
```

This allows empty arrays (which represent "no reminders") to be applied to Google Calendar events.

## Testing
- All DND-related tests pass (20 examples, 0 failures)
- PreferenceResolver tests pass (38 examples, 0 failures)
- Rubocop passes with no offenses

## Notes
- The ICS calendar implementation was checked but doesn't include reminders, so no changes needed there
- This fix ensures that when users enable DND mode, their Google Calendar events will be updated to remove all notifications

Fixes #295