### PR TITLE
fix: make CI deployment more robust by properly handling screen sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,12 +199,12 @@ jobs:
           SERVER_HOST: ${{ secrets.SERVER_HOST }}
         run: |
           ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes jsp@"$SERVER_HOST" << 'EOF'
-            # Stop the server (send Ctrl+C to screen)
-            screen -S witcal-prod-server -p 0 -X stuff $'\003'
+            # Kill existing screen session if it exists
+            screen -S witcal-prod-server -X quit 2>/dev/null || true
             sleep 2
 
-            # Pull latest code, run migrations, and restart
-            screen -S witcal-prod-server -p 0 -X stuff 'cd /Users/jsp/server/calendar-backend && git pull && RAILS_ENV=production bundle exec rails db:migrate && RAILS_ENV=production rails server\n'
+            # Create a new detached screen session that pulls code, migrates, and starts server
+            screen -dmS witcal-prod-server bash -c 'cd /Users/jsp/server/calendar-backend && git pull && RAILS_ENV=production bundle exec rails db:migrate && exec RAILS_ENV=production rails server'
           EOF
 
       - name: Verify Deployment


### PR DESCRIPTION
## Summary
- Fixes the deployment failure where screen session commands fail when the screen doesn't exist
- Kills existing screen session gracefully (doesn't fail if missing)
- Creates fresh detached screen with deployment commands

## Changes
- Replace `screen -X stuff` approach with `screen -dmS` to create proper detached screen
- Use `screen -X quit` with error suppression to handle missing screens
- Run commands in proper bash shell instead of sending terminal input

## Testing
- This should fix the "No screen session found" errors in CI deployment
- The deployment will now work whether or not a screen session exists

Fixes the deployment issues seen in recent CI runs.