### PR TITLE
fix: trigger calendar sync when DND is disabled

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -431,6 +431,12 @@ module Api
 
       current_user.enable_notifications!
 
+      # Trigger calendar sync to restore reminders
+      # The sync job will gracefully handle cases where user has no Google Calendar
+      current_user.update_column(:calendar_needs_sync, true) # rubocop:disable Rails/SkipsModelValidations
+      GoogleCalendarSyncJob.perform_later(current_user, force: true)
+
+
       render json: {
         message: "Notifications enabled",
         notifications_disabled: false,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe User do
         expect(user.notifications_disabled_until).to be_nil
         expect(user.notifications_disabled?).to be false
       end
+
     end
   end
 end


### PR DESCRIPTION
## Summary
- Fixes issue where disabling DND (re-enabling notifications) doesn't restore reminders in Google Calendar
- When `/api/user/notifications/enable` is called, the system now triggers an immediate calendar sync

## Changes
- Modified `Api::UsersController#enable_notifications` to mark `calendar_needs_sync` and enqueue `GoogleCalendarSyncJob`
- This ensures reminders are immediately pushed back to Google Calendar when notifications are re-enabled

## Testing
- All existing tests pass
- Manual testing recommended to verify calendar reminders are restored after re-enabling notifications

## Closes
Closes #301