### PR TITLE
feat: add rake tasks to detect and clean up ghost events

### DIFF
--- a/lib/tasks/cleanup_duplicate_university_events.rake
+++ b/lib/tasks/cleanup_duplicate_university_events.rake
@@ -161,4 +161,226 @@ namespace :university_calendar do
       puts "\nNo duplicates found!"
     end
   end
+
+  desc "Check for orphaned GoogleCalendarEvent records (dry run)"
+  task check_orphaned_gcal_events: :environment do
+    puts "=== Checking for orphaned Google Calendar events ==="
+    puts ""
+
+    # Find GoogleCalendarEvent records pointing to non-existent UniversityCalendarEvents
+    orphaned = GoogleCalendarEvent.left_joins(:university_calendar_event)
+                                   .where(university_calendar_events: { id: nil })
+                                   .where.not(university_calendar_event_id: nil)
+
+    puts "Total GoogleCalendarEvent records: #{GoogleCalendarEvent.count}"
+    puts "Orphaned records found: #{orphaned.count}"
+    puts ""
+
+    if orphaned.any?
+      # Group by calendar for better output
+      by_calendar = orphaned.group_by(&:google_calendar_id)
+
+      by_calendar.each do |calendar_id, events|
+        calendar = GoogleCalendar.find_by(id: calendar_id)
+        user_email = calendar&.oauth_credential&.user&.primary_email&.email || "Unknown"
+
+        puts "Calendar ID #{calendar_id} (User: #{user_email}):"
+        puts "  #{events.count} orphaned events"
+
+        # Show sample events
+        events.first(5).each do |gce|
+          puts "    - DB ID: #{gce.id}, GoogleEventID: #{gce.google_event_id}, Missing UniversityEvent: #{gce.university_calendar_event_id}"
+        end
+
+        puts "    ... and #{events.count - 5} more" if events.count > 5
+        puts ""
+      end
+
+      puts "\nThese orphaned records are causing duplicate events in Google Calendar."
+      puts "They reference UniversityCalendarEvent records that no longer exist."
+      puts "\nRun 'rails university_calendar:cleanup_orphaned_gcal_events' to remove them."
+    else
+      puts "No orphaned records found!"
+    end
+  end
+
+  desc "Clean up orphaned GoogleCalendarEvent records"
+  task cleanup_orphaned_gcal_events: :environment do
+    puts "=== Cleaning up orphaned Google Calendar events ==="
+    puts ""
+
+    # Find orphaned records
+    orphaned = GoogleCalendarEvent.left_joins(:university_calendar_event)
+                                   .where(university_calendar_events: { id: nil })
+                                   .where.not(university_calendar_event_id: nil)
+
+    total = orphaned.count
+    puts "Found #{total} orphaned GoogleCalendarEvent records"
+    return if total.zero?
+
+    deleted_from_gcal = 0
+    deleted_from_db = 0
+    errors = 0
+
+    orphaned.find_each do |gce|
+      begin
+        calendar = gce.google_calendar
+        next unless calendar
+
+        # Delete from Google Calendar
+        service = GoogleCalendarService.new(calendar.oauth_credential)
+        begin
+          service.delete_event(calendar.calendar_id, gce.google_event_id)
+          deleted_from_gcal += 1
+          puts "Deleted from Google Calendar: #{gce.google_event_id} (Calendar: #{calendar.id})"
+        rescue Google::Apis::ClientError => e
+          if e.status_code == 404 || e.status_code == 410
+            # Event already deleted from Google Calendar, just clean up DB
+            puts "Event already gone from Google Calendar: #{gce.google_event_id}"
+          else
+            raise
+          end
+        end
+
+        # Delete from database
+        gce.destroy
+        deleted_from_db += 1
+      rescue => e
+        errors += 1
+        puts "Error processing GoogleCalendarEvent #{gce.id}: #{e.message}"
+        Rails.logger.error("Failed to cleanup orphaned GoogleCalendarEvent #{gce.id}: #{e.message}")
+      end
+    end
+
+    puts "\n=== Cleanup Complete ==="
+    puts "Deleted from Google Calendar: #{deleted_from_gcal}"
+    puts "Deleted from database: #{deleted_from_db}"
+    puts "Errors: #{errors}"
+
+    if deleted_from_db > 0
+      puts "\nTriggering calendar sync for all users to ensure consistency..."
+      User.joins(oauth_credentials: :google_calendar).distinct.find_each do |user|
+        GoogleCalendarSyncJob.perform_later(user, force: true)
+      end
+      puts "Calendar sync jobs queued."
+    end
+  end
+
+  desc "Check for ghost events in Google Calendar (exist in GCal but not in our database)"
+  task check_ghost_events: :environment do
+    puts "=== Checking for ghost events in Google Calendar ==="
+    puts "These are events that exist in Google Calendar but aren't tracked in our database"
+    puts ""
+
+    total_ghost_events = 0
+    total_tracked_events = 0
+
+    GoogleCalendar.find_each do |calendar|
+      user_email = calendar.oauth_credential&.user&.primary_email&.email || "Unknown"
+      puts "\nChecking calendar #{calendar.id} (User: #{user_email})..."
+
+      begin
+        service = GoogleCalendarService.new(calendar.oauth_credential)
+
+        # Fetch all university calendar events from Google Calendar
+        gcal_events = service.list_events(calendar.calendar_id)
+
+        # Get all tracked event IDs for this calendar
+        tracked_event_ids = calendar.google_calendar_events.pluck(:google_event_id).to_set
+
+        # Find events in GCal that aren't tracked in our DB
+        ghost_events = gcal_events.reject { |e| tracked_event_ids.include?(e.id) }
+
+        total_tracked_events += tracked_event_ids.size
+        total_ghost_events += ghost_events.size
+
+        if ghost_events.any?
+          puts "  Found #{ghost_events.size} ghost events (out of #{gcal_events.size} total events)"
+
+          # Show details of ghost events
+          ghost_events.first(10).each do |event|
+            puts "    - #{event.summary} (#{event.start&.date_time || event.start&.date}) [ID: #{event.id}]"
+          end
+
+          puts "    ... and #{ghost_events.size - 10} more" if ghost_events.size > 10
+        else
+          puts "  No ghost events found (#{gcal_events.size} events, all tracked)"
+        end
+      rescue => e
+        puts "  Error checking calendar: #{e.message}"
+        Rails.logger.error("Failed to check ghost events for calendar #{calendar.id}: #{e.message}")
+      end
+    end
+
+    puts "\n=== Summary ==="
+    puts "Total tracked events in database: #{total_tracked_events}"
+    puts "Total ghost events in Google Calendar: #{total_ghost_events}"
+
+    if total_ghost_events > 0
+      puts "\nThese ghost events are likely causing duplicates."
+      puts "Run 'rails university_calendar:cleanup_ghost_events' to remove them."
+    else
+      puts "\nNo ghost events found!"
+    end
+  end
+
+  desc "Clean up ghost events in Google Calendar (exist in GCal but not in our database)"
+  task cleanup_ghost_events: :environment do
+    puts "=== Cleaning up ghost events in Google Calendar ==="
+    puts ""
+
+    total_deleted = 0
+    total_errors = 0
+
+    GoogleCalendar.find_each do |calendar|
+      user_email = calendar.oauth_credential&.user&.primary_email&.email || "Unknown"
+      puts "\nProcessing calendar #{calendar.id} (User: #{user_email})..."
+
+      begin
+        service = GoogleCalendarService.new(calendar.oauth_credential)
+
+        # Fetch all university calendar events from Google Calendar
+        gcal_events = service.list_events(calendar.calendar_id)
+
+        # Get all tracked event IDs for this calendar
+        tracked_event_ids = calendar.google_calendar_events.pluck(:google_event_id).to_set
+
+        # Find events in GCal that aren't tracked in our DB
+        ghost_events = gcal_events.reject { |e| tracked_event_ids.include?(e.id) }
+
+        if ghost_events.any?
+          puts "  Deleting #{ghost_events.size} ghost events..."
+
+          ghost_events.each do |event|
+            begin
+              service.delete_event(calendar.calendar_id, event.id)
+              total_deleted += 1
+              puts "    Deleted: #{event.summary} [ID: #{event.id}]"
+            rescue => e
+              total_errors += 1
+              puts "    Error deleting #{event.id}: #{e.message}"
+              Rails.logger.error("Failed to delete ghost event #{event.id}: #{e.message}")
+            end
+          end
+        else
+          puts "  No ghost events to delete"
+        end
+      rescue => e
+        puts "  Error processing calendar: #{e.message}"
+        Rails.logger.error("Failed to cleanup ghost events for calendar #{calendar.id}: #{e.message}")
+      end
+    end
+
+    puts "\n=== Cleanup Complete ==="
+    puts "Ghost events deleted: #{total_deleted}"
+    puts "Errors: #{total_errors}"
+
+    if total_deleted > 0
+      puts "\nTriggering calendar sync for all users to ensure consistency..."
+      User.joins(oauth_credentials: :google_calendar).distinct.find_each do |user|
+        GoogleCalendarSyncJob.perform_later(user, force: true)
+      end
+      puts "Calendar sync jobs queued."
+    end
+  end
 end


### PR DESCRIPTION
## Summary
Adds rake tasks to find and remove "ghost" events that exist in Google Calendar but aren't tracked in our database, which cause duplicate events to appear.

## Problem
Users are seeing duplicate events in Google Calendar (e.g., duplicate Wellbeing Day events). When changing uni cal color preferences, only one of the duplicates updates - indicating one event is tracked by our system while the other is not.

This happens when:
- Events exist in Google Calendar but have no corresponding `GoogleCalendarEvent` record in our DB
- Old `GoogleCalendarEvent` records point to deleted `UniversityCalendarEvent` records

## Solution
Four new rake tasks to detect and clean up these issues:

### Ghost Events (events in GCal not in our DB)
- `rails university_calendar:check_ghost_events` - Dry run to find untracked events
- `rails university_calendar:cleanup_ghost_events` - Delete untracked events from Google Calendar

### Orphaned DB Records (DB records pointing to deleted events)  
- `rails university_calendar:check_orphaned_gcal_events` - Find DB records with missing references
- `rails university_calendar:cleanup_orphaned_gcal_events` - Clean up orphaned DB records and delete from GCal

## Usage
1. Check for ghost events: `RAILS_ENV=production bundle exec rails university_calendar:check_ghost_events`
2. If found, clean them up: `RAILS_ENV=production bundle exec rails university_calendar:cleanup_ghost_events`

## Test Plan
- [x] Run check tasks in production to identify ghost events
- [ ] Run cleanup tasks to remove duplicates
- [ ] Verify duplicates are removed from Google Calendar
- [ ] Confirm color changes apply to all events after cleanup

Fixes #291