### PR TITLE
hotfix: use User.email instead of primary_email.email

### DIFF
--- a/lib/tasks/cleanup_duplicate_university_events.rake
+++ b/lib/tasks/cleanup_duplicate_university_events.rake
@@ -182,7 +182,7 @@ namespace :university_calendar do
 
       by_calendar.each do |calendar_id, events|
         calendar = GoogleCalendar.find_by(id: calendar_id)
-        user_email = calendar&.oauth_credential&.user&.primary_email&.email || "Unknown"
+        user_email = calendar&.oauth_credential&.user&.email || "Unknown"
 
         puts "Calendar ID #{calendar_id} (User: #{user_email}):"
         puts "  #{events.count} orphaned events"
@@ -276,7 +276,7 @@ namespace :university_calendar do
     total_tracked_events = 0
 
     GoogleCalendar.find_each do |calendar|
-      user_email = calendar.oauth_credential&.user&.primary_email&.email || "Unknown"
+      user_email = calendar.oauth_credential&.user&.email || "Unknown"
       puts "\nChecking calendar #{calendar.id} (User: #{user_email})..."
 
       begin
@@ -333,7 +333,7 @@ namespace :university_calendar do
     total_errors = 0
 
     GoogleCalendar.find_each do |calendar|
-      user_email = calendar.oauth_credential&.user&.primary_email&.email || "Unknown"
+      user_email = calendar.oauth_credential&.user&.email || "Unknown"
       puts "\nProcessing calendar #{calendar.id} (User: #{user_email})..."
 
       begin


### PR DESCRIPTION
Fixes NoMethodError when running ghost event cleanup tasks.

User model has an `email` method that returns the primary email, not `primary_email.email`.

Fixes the error:
```
NoMethodError: undefined method 'primary_email' for an instance of User
```

Related to #291