### PR TITLE
feat: create PORO API serializers

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -6,6 +6,7 @@ module Api
     include JsonWebTokenAuthenticatable
     include FeatureFlagGated
     include PublicIdLookupable
+    include PreferenceSerializable
 
     self.gated_feature_key = :v1
 
@@ -43,47 +44,6 @@ module Api
       else
         render json: { error: "Internal server error" }, status: :internal_server_error
       end
-    end
-
-    # Transform reminder settings to use "notification" instead of "popup"
-    # Google Calendar uses "popup", but we alias it to "notification" in our API
-    def transform_reminder_settings(reminder_settings)
-      return nil if reminder_settings.nil?
-      return [] if reminder_settings.empty?
-
-      reminder_settings.map do |reminder|
-        reminder = reminder.deep_symbolize_keys if reminder.is_a?(Hash)
-        next reminder unless reminder.is_a?(Hash)
-
-        reminder[:method] = "notification" if reminder[:method] == "popup"
-        reminder.transform_keys(&:to_s) # Ensure string keys for JSON
-      end
-    end
-
-    # Normalize color to WITCC hex format for API responses
-    # Handles: integers (1-11), WITCC hex (already correct), Google event hex (convert to WITCC)
-    # @param color_id_or_hex [Integer, String, nil] Color ID or hex string
-    # @return [String, nil] WITCC hex color or nil
-    def normalize_color_to_witcc_hex(color_id_or_hex)
-      return nil if color_id_or_hex.blank?
-
-      # If it's an integer, convert to WITCC hex
-      if color_id_or_hex.is_a?(Integer)
-        return GoogleColors.to_witcc_hex(color_id_or_hex)
-      end
-
-      # If it's a hex string, check if it's already a WITCC color
-      if color_id_or_hex.is_a?(String) && color_id_or_hex.start_with?("#")
-        normalized_hex = color_id_or_hex.downcase
-
-        # Check if it's already a WITCC color (key in WITCC_MAP)
-        return normalized_hex if GoogleColors::WITCC_MAP.key?(normalized_hex)
-
-        # Otherwise try to convert from Google event hex to WITCC hex
-        return GoogleColors.to_witcc_hex(color_id_or_hex)
-      end
-
-      nil
     end
 
   end

--- a/app/controllers/api/event_preferences_controller.rb
+++ b/app/controllers/api/event_preferences_controller.rb
@@ -29,7 +29,7 @@ module Api
       resolved_prefs[:color_id] = normalize_color_to_witcc_hex(resolved_prefs[:color_id])
 
       render json: {
-        individual_preference: preference ? event_preference_json(preference) : nil,
+        individual_preference: preference ? EventPreferenceSerializer.new(preference).as_json : nil,
         resolved: resolved_prefs,
         sources: resolved_data[:sources],
         preview: preview,
@@ -70,7 +70,7 @@ module Api
         resolved_prefs[:color_id] = normalize_color_to_witcc_hex(resolved_prefs[:color_id])
 
         render json: {
-          individual_preference: event_preference_json(preference),
+          individual_preference: EventPreferenceSerializer.new(preference).as_json,
           resolved: resolved_prefs,
           sources: resolved_data[:sources],
           preview: preview,
@@ -148,17 +148,6 @@ module Api
       end
 
       permitted
-    end
-
-    def event_preference_json(preference)
-      {
-        title_template: preference.title_template,
-        description_template: preference.description_template,
-        location_template: preference.location_template,
-        reminder_settings: transform_reminder_settings(preference.reminder_settings),
-        color_id: normalize_color_to_witcc_hex(preference.color_id),
-        visibility: preference.visibility
-      }
     end
 
     def generate_preview(resolved_preferences, context)

--- a/app/controllers/api/misc_controller.rb
+++ b/app/controllers/api/misc_controller.rb
@@ -10,23 +10,9 @@ module Api
       next_term = Term.next
 
       render json: {
-        current_term: term_json(current_term),
-        next_term: term_json(next_term)
+        current_term: TermSerializer.new(current_term).as_json,
+        next_term: TermSerializer.new(next_term).as_json
       }, status: :ok
-    end
-
-    private
-
-    def term_json(term)
-      return nil if term.nil?
-
-      {
-        name: term.name,
-        id: term.uid,
-        pub_id: term.public_id,
-        start_date: term.start_date,
-        end_date: term.end_date
-      }
     end
 
   end

--- a/app/controllers/api/university_calendar_events_controller.rb
+++ b/app/controllers/api/university_calendar_events_controller.rb
@@ -39,7 +39,7 @@ module Api
       @events = @events.page(params[:page]).per(params[:per_page] || 25)
 
       render json: {
-        events: @events.map { |e| serialize_event(e) },
+        events: @events.map { |e| UniversityCalendarEventSerializer.new(e).as_json },
         meta: pagination_meta(@events)
       }
     end
@@ -47,7 +47,7 @@ module Api
     # GET /api/university_calendar_events/:id
     def show
       authorize @event
-      render json: { event: serialize_event(@event) }
+      render json: { event: UniversityCalendarEventSerializer.new(@event).as_json }
     end
 
     # GET /api/university_calendar_events/categories
@@ -87,7 +87,7 @@ module Api
       end
 
       render json: {
-        holidays: @holidays.map { |h| serialize_event(h) }
+        holidays: @holidays.map { |h| UniversityCalendarEventSerializer.new(h).as_json }
       }
     end
 
@@ -105,26 +105,6 @@ module Api
     def set_event
       @event = UniversityCalendarEvent.find_by_public_id(params[:id])
       raise ActiveRecord::RecordNotFound, "UniversityCalendarEvent not found" unless @event
-    end
-
-    def serialize_event(event)
-      {
-        id: event.public_id,
-        summary: event.summary,
-        description: event.description,
-        location: event.location,
-        start_time: event.start_time.iso8601,
-        end_time: event.end_time.iso8601,
-        all_day: event.all_day,
-        category: event.category,
-        organization: event.organization,
-        academic_term: event.academic_term,
-        term_id: event.term&.public_id,
-        excludes_classes: event.excludes_classes?,
-        formatted_date: event.formatted_date,
-        created_at: event.created_at.iso8601,
-        updated_at: event.updated_at.iso8601
-      }
     end
 
     def pagination_meta(collection)

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -2,8 +2,6 @@
 
 module Api
   class UsersController < ApiController
-    include ApplicationHelper
-
     skip_before_action :authenticate_user_from_token!, only: [:onboard]
     skip_before_action :check_beta_access, only: [:onboard, :get_email]
 
@@ -244,84 +242,6 @@ module Api
       render json: { error: "Failed to request Google Calendar" }, status: :internal_server_error
     end
 
-    def group_meeting_times(meeting_times)
-      # Create preference resolver for the user
-      preference_resolver = PreferenceResolver.new(current_user)
-      template_renderer = CalendarTemplateRenderer.new
-
-      # Return each meeting time individually with its own ID
-      # This ensures each day can be edited independently in the extension
-      meeting_times.map do |mt|
-        # Initialize days object with only this meeting time's day set to true
-        days = {
-          monday: false,
-          tuesday: false,
-          wednesday: false,
-          thursday: false,
-          friday: false,
-          saturday: false,
-          sunday: false
-        }
-
-        # Set only the current meeting time's day to true
-        day_symbol = mt.day_of_week&.to_sym
-        days[day_symbol] = true if day_symbol
-
-        # Resolve preferences for this meeting time (ignore DND for display purposes)
-        preferences = preference_resolver.resolve_actual_for(mt)
-
-        # Build template context
-        context = CalendarTemplateRenderer.build_context_from_meeting_time(mt)
-
-        # Render title and description from templates
-        rendered_title = if preferences[:title_template].present?
-                           template_renderer.render(preferences[:title_template], context)
-                         else
-                           titleize_with_roman_numerals(mt.course.title)
-                         end
-
-        rendered_description = if preferences[:description_template].present?
-                                 template_renderer.render(preferences[:description_template], context)
-                               else
-                                 nil
-                               end
-
-        # Convert color to WITCC hex format
-        # Use preference color if set, otherwise use meeting time's default color
-        color_value = preferences[:color_id] || mt.event_color
-        witcc_color = GoogleColors.to_witcc_hex(color_value)
-
-        {
-          id: mt.public_id,
-          begin_time: mt.fmt_begin_time_military,
-          end_time: mt.fmt_end_time_military,
-          start_date: mt.start_date,
-          end_date: mt.end_date,
-          location: {
-            building: if mt.building
-                        {
-                          pub_id: mt.building.public_id,
-                          name: mt.building.name,
-                          abbreviation: mt.building.abbreviation
-                        }
-                      else
-                        nil
-                      end,
-            room: mt.room&.formatted_number
-          },
-          **days,
-          # Preference-resolved calendar configuration
-          calendar_config: {
-            title: rendered_title,
-            description: rendered_description,
-            color_id: witcc_color,
-            reminder_settings: preferences[:reminder_settings],
-            visibility: preferences[:visibility]
-          }
-        }
-      end
-    end
-
     def get_ics_url
       authorize current_user, :show?
 
@@ -490,55 +410,16 @@ module Api
                                 { meeting_times: [:event_preference, { room: :building }, { course: :faculties }] }
                               ])
 
+      preference_resolver = PreferenceResolver.new(current_user)
+      template_renderer = CalendarTemplateRenderer.new
+
       structured_data = enrollments.map do |enrollment|
-        course = enrollment.course
-        faculty = course.faculties.first # safer than [0]
-
-        # Filter meeting times to prefer valid locations over TBD duplicates
-        filtered_meeting_times = course.meeting_times.group_by { |mt| [mt.day_of_week, mt.begin_time, mt.end_time] }
-                                       .map do |key, meeting_times_group|
-                                         # Log duplicate detection
-                                         if meeting_times_group.size > 1
-                                           Rails.logger.info "[API] Duplicate meeting times detected for course #{course.crn}: #{meeting_times_group.size} entries for #{key.inspect}"
-                                         end
-
-                                         # If multiple meeting times exist for same day/time, prefer non-TBD over TBD
-                                         non_tbd = meeting_times_group.reject { |mt| (mt.building && current_user.send(:tbd_building?, mt.building)) || (mt.room && current_user.send(:tbd_room?, mt.room)) }
-                                         # Take only the first valid one, or first TBD if no valid ones
-                                         selected = non_tbd.any? ? non_tbd.first : meeting_times_group.first
-
-                                         if meeting_times_group.size > 1
-                                           Rails.logger.info "[API] Selected meeting time #{selected.id} with location: #{selected.building&.name} - #{selected.room&.number}"
-                                         end
-
-                                         selected
-        end
-
-        {
-          title: titleize_with_roman_numerals(course.title),
-          course_number: course.course_number,
-          schedule_type: course.schedule_type,
-          prefix: course.prefix,
-          term: {
-            pub_id: term.public_id,
-            uid: term.uid,
-            season: term.season,
-            year: term.year
-          },
-          professor: if faculty
-                       {
-                         pub_id: faculty.public_id,
-                         first_name: faculty.first_name,
-                         last_name: faculty.last_name,
-                         email: faculty.email,
-                         rmp_id: faculty.rmp_id
-                       }
-                     else
-                       nil
-                     end,
-          # Note: We pass filtered_meeting_times (not grouped) to ensure each day has unique ID
-          meeting_times: group_meeting_times(filtered_meeting_times)
-        }
+        EnrolledCourseSerializer.new(
+          enrollment,
+          term: term,
+          preference_resolver: preference_resolver,
+          template_renderer: template_renderer
+        ).as_json
       end
 
       render json: {

--- a/app/serializers/calendar_preference_serializer.rb
+++ b/app/serializers/calendar_preference_serializer.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class CalendarPreferenceSerializer
+  include PreferenceSerializable
+
+  def initialize(preference)
+    @preference = preference
+  end
+
+  def as_json(*)
+    {
+      scope: @preference.scope,
+      event_type: @preference.event_type,
+      title_template: @preference.title_template,
+      description_template: @preference.description_template,
+      location_template: @preference.location_template,
+      reminder_settings: transform_reminder_settings(@preference.reminder_settings),
+      color_id: normalize_color_to_witcc_hex(@preference.color_id),
+      visibility: @preference.visibility
+    }
+  end
+
+end

--- a/app/serializers/concerns/preference_serializable.rb
+++ b/app/serializers/concerns/preference_serializable.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Shared serialization helpers for preference-related serializers and controllers.
+# Handles reminder method aliasing ("popup" -> "notification") and color normalization.
+module PreferenceSerializable
+  private
+
+  # Transform reminder settings to use "notification" instead of "popup"
+  # Google Calendar uses "popup", but we alias it to "notification" in our API
+  def transform_reminder_settings(reminder_settings)
+    return nil if reminder_settings.nil?
+    return [] if reminder_settings.empty?
+
+    reminder_settings.map do |reminder|
+      reminder = reminder.deep_symbolize_keys if reminder.is_a?(Hash)
+      next reminder unless reminder.is_a?(Hash)
+
+      reminder[:method] = "notification" if reminder[:method] == "popup"
+      reminder.transform_keys(&:to_s)
+    end
+  end
+
+  # Normalize color to WITCC hex format for API responses
+  # Handles: integers (1-11), WITCC hex (already correct), Google event hex (convert to WITCC)
+  # @param color_id_or_hex [Integer, String, nil] Color ID or hex string
+  # @return [String, nil] WITCC hex color or nil
+  def normalize_color_to_witcc_hex(color_id_or_hex)
+    return nil if color_id_or_hex.blank?
+
+    if color_id_or_hex.is_a?(Integer)
+      return GoogleColors.to_witcc_hex(color_id_or_hex)
+    end
+
+    if color_id_or_hex.is_a?(String) && color_id_or_hex.start_with?("#")
+      normalized_hex = color_id_or_hex.downcase
+      return normalized_hex if GoogleColors::WITCC_MAP.key?(normalized_hex)
+
+      return GoogleColors.to_witcc_hex(color_id_or_hex)
+    end
+
+    nil
+  end
+end

--- a/app/serializers/enrolled_course_serializer.rb
+++ b/app/serializers/enrolled_course_serializer.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# Serializes a course enrollment into structured JSON for the browser extension.
+# Handles meeting time deduplication (preferring non-TBD locations) and
+# preference resolution for each meeting time.
+class EnrolledCourseSerializer
+  include ApplicationHelper
+
+  # @param enrollment [Enrollment]
+  # @param term [Term]
+  # @param preference_resolver [PreferenceResolver] shared resolver instance across a collection
+  # @param template_renderer [CalendarTemplateRenderer] shared renderer instance across a collection
+  def initialize(enrollment, term:, preference_resolver:, template_renderer:)
+    @enrollment = enrollment
+    @term = term
+    @preference_resolver = preference_resolver
+    @template_renderer = template_renderer
+  end
+
+  def as_json(*)
+    course = @enrollment.course
+    faculty = course.faculties.first
+    filtered_meeting_times = deduplicate_meeting_times(course.meeting_times)
+
+    {
+      title: titleize_with_roman_numerals(course.title),
+      course_number: course.course_number,
+      schedule_type: course.schedule_type,
+      prefix: course.prefix,
+      term: TermSerializer.new(@term).as_json,
+      professor: FacultySerializer.new(faculty).as_json,
+      meeting_times: filtered_meeting_times.map do |mt|
+        MeetingTimeSerializer.new(mt, preference_resolver: @preference_resolver, template_renderer: @template_renderer).as_json
+      end
+    }
+  end
+
+  private
+
+  # Filter meeting times to prefer valid locations over TBD duplicates.
+  # When multiple meeting times share the same day/time slot, pick non-TBD over TBD.
+  def deduplicate_meeting_times(meeting_times)
+    meeting_times.group_by { |mt| [mt.day_of_week, mt.begin_time, mt.end_time] }
+                 .map do |_key, group|
+                   if group.size > 1
+                     Rails.logger.info "[EnrolledCourseSerializer] Duplicate meeting times: #{group.size} entries for course #{group.first.course_id}"
+                   end
+
+                   non_tbd = group.reject { |mt| tbd_building?(mt.building) || tbd_room?(mt.room) }
+                   non_tbd.any? ? non_tbd.first : group.first
+                 end
+  end
+
+  def tbd_building?(building)
+    return false unless building
+
+    building.name.blank? ||
+      building.abbreviation.blank? ||
+      building.name&.downcase&.include?("to be determined") ||
+      building.name&.downcase&.include?("tbd") ||
+      building.abbreviation&.downcase == "tbd"
+  end
+
+  def tbd_room?(room)
+    return false unless room
+
+    room.number == 0
+  end
+
+end

--- a/app/serializers/event_preference_serializer.rb
+++ b/app/serializers/event_preference_serializer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class EventPreferenceSerializer
+  include PreferenceSerializable
+
+  def initialize(preference)
+    @preference = preference
+  end
+
+  def as_json(*)
+    {
+      title_template: @preference.title_template,
+      description_template: @preference.description_template,
+      location_template: @preference.location_template,
+      reminder_settings: transform_reminder_settings(@preference.reminder_settings),
+      color_id: normalize_color_to_witcc_hex(@preference.color_id),
+      visibility: @preference.visibility
+    }
+  end
+
+end

--- a/app/serializers/faculty_serializer.rb
+++ b/app/serializers/faculty_serializer.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class FacultySerializer
+  def initialize(faculty)
+    @faculty = faculty
+  end
+
+  def as_json(*)
+    return nil if @faculty.nil?
+
+    {
+      pub_id: @faculty.public_id,
+      first_name: @faculty.first_name,
+      last_name: @faculty.last_name,
+      email: @faculty.email,
+      rmp_id: @faculty.rmp_id
+    }
+  end
+
+end

--- a/app/serializers/meeting_time_serializer.rb
+++ b/app/serializers/meeting_time_serializer.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+class MeetingTimeSerializer
+  include ApplicationHelper
+
+  # @param meeting_time [MeetingTime]
+  # @param preference_resolver [PreferenceResolver] shared resolver instance across a collection
+  # @param template_renderer [CalendarTemplateRenderer] shared renderer instance across a collection
+  def initialize(meeting_time, preference_resolver:, template_renderer:)
+    @mt = meeting_time
+    @preference_resolver = preference_resolver
+    @template_renderer = template_renderer
+  end
+
+  def as_json(*)
+    preferences = @preference_resolver.resolve_actual_for(@mt)
+    context = CalendarTemplateRenderer.build_context_from_meeting_time(@mt)
+
+    rendered_title = if preferences[:title_template].present?
+                       @template_renderer.render(preferences[:title_template], context)
+                     else
+                       titleize_with_roman_numerals(@mt.course.title)
+                     end
+
+    rendered_description = if preferences[:description_template].present?
+                             @template_renderer.render(preferences[:description_template], context)
+                           end
+
+    color_value = preferences[:color_id] || @mt.event_color
+    witcc_color = GoogleColors.to_witcc_hex(color_value)
+
+    {
+      id: @mt.public_id,
+      begin_time: @mt.fmt_begin_time_military,
+      end_time: @mt.fmt_end_time_military,
+      start_date: @mt.start_date,
+      end_date: @mt.end_date,
+      location: {
+        building: building_json,
+        room: @mt.room&.formatted_number
+      },
+      **days,
+      calendar_config: {
+        title: rendered_title,
+        description: rendered_description,
+        color_id: witcc_color,
+        reminder_settings: preferences[:reminder_settings],
+        visibility: preferences[:visibility]
+      }
+    }
+  end
+
+  private
+
+  def days
+    result = {
+      monday: false,
+      tuesday: false,
+      wednesday: false,
+      thursday: false,
+      friday: false,
+      saturday: false,
+      sunday: false
+    }
+    day_symbol = @mt.day_of_week&.to_sym
+    result[day_symbol] = true if day_symbol
+    result
+  end
+
+  def building_json
+    return nil unless @mt.building
+
+    {
+      pub_id: @mt.building.public_id,
+      name: @mt.building.name,
+      abbreviation: @mt.building.abbreviation
+    }
+  end
+
+end

--- a/app/serializers/term_serializer.rb
+++ b/app/serializers/term_serializer.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class TermSerializer
+  def initialize(term)
+    @term = term
+  end
+
+  def as_json(*)
+    return nil if @term.nil?
+
+    {
+      name: @term.name,
+      id: @term.uid,
+      pub_id: @term.public_id,
+      start_date: @term.start_date,
+      end_date: @term.end_date
+    }
+  end
+
+end

--- a/app/serializers/university_calendar_event_serializer.rb
+++ b/app/serializers/university_calendar_event_serializer.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class UniversityCalendarEventSerializer
+  def initialize(event)
+    @event = event
+  end
+
+  def as_json(*)
+    {
+      id: @event.public_id,
+      summary: @event.summary,
+      description: @event.description,
+      location: @event.location,
+      start_time: @event.start_time.iso8601,
+      end_time: @event.end_time.iso8601,
+      all_day: @event.all_day,
+      category: @event.category,
+      organization: @event.organization,
+      academic_term: @event.academic_term,
+      term_id: @event.term&.public_id,
+      excludes_classes: @event.excludes_classes?,
+      formatted_date: @event.formatted_date,
+      created_at: @event.created_at.iso8601,
+      updated_at: @event.updated_at.iso8601
+    }
+  end
+
+end

--- a/db/migrate/20260210003917_add_special_prerequisite_support.rb
+++ b/db/migrate/20260210003917_add_special_prerequisite_support.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSpecialPrerequisiteSupport < ActiveRecord::Migration[8.1]
+  def change
+  end
+
+end

--- a/docs/prerequisite-system/architecture.md
+++ b/docs/prerequisite-system/architecture.md
@@ -1,0 +1,953 @@
+# Prerequisite System Architecture
+
+## Research Summary
+
+### Data Source: catalog.wit.edu
+
+**URL Pattern**: `https://catalog.wit.edu/course-descriptions/[dept]/`
+
+Where `[dept]` is lowercase department code (comp, math, chem, etc.)
+
+### Prerequisite Formatting Patterns
+
+Based on analysis of Computer Science, Mathematics, and Chemistry catalogs:
+
+#### 1. HTML Structure
+- Prerequisites appear in `<em>` or `<i>` tags at end of course descriptions
+- Course codes are hyperlinked: `<a href="/search/?P=COMP1000">COMP1000</a>`
+- Label format: "Prerequisite:" (singular) or "Prerequisites:" (plural)
+- Corequisite format: "Corequisite:" followed by course code
+
+#### 2. Logical Operators
+- **AND**: Expressed as " and " or ", " or "; " between course codes
+  - Examples:
+    - "COMP2000 and COMP2350 and MATH2100"
+    - "MATH1800, MATH1850, MATH1877"
+- **OR**: Expressed as " or " between course codes
+  - Examples:
+    - "COMP1000 or ELEC3150"
+    - "MATH1877 or MATH1875"
+- **Mixed**: Semicolon separates distinct requirement groups
+  - Example: "COMP1050; MATH2300 or MATH2800" (requires COMP1050 AND (MATH2300 OR MATH2800))
+
+#### 3. Grade Requirements
+- Format: "course_code completed with a grade of X or better"
+- Example: "MATH2100 completed with a grade of B or better"
+- Grades: A, B, C, D (standard letter grades)
+
+#### 4. Special Prerequisites
+- **Placement**: "MATH Placement" or "MATH1000 or MATH Placement"
+- **Permission**: "Consent of the academic unit and instructor"
+- **Enrollment**: "Enrollment in MSCA Program"
+
+#### 5. Corequisites
+- Courses required concurrently (same semester)
+- Format: "Corequisite: MATH1000"
+- Common for lab/lecture pairings
+
+### Key Observations
+1. No nested prerequisite logic (no parentheses)
+2. Grade requirements are uncommon but exist
+3. Corequisites are explicitly labeled
+4. Semicolon acts as higher-precedence AND separator
+5. Course codes follow pattern: [A-Z]{4}[0-9]{4}
+
+---
+
+## Design Decisions (From Test Coverage Review)
+
+### 1. Circular Dependency Handling
+
+**Decision**: Store at parse time, detect and warn at validation time
+
+**Reasoning**:
+- Parser should be faithful to source data - if catalog has circular deps, parse as-is
+- Validation service is the right place to detect cycles and return meaningful errors
+- Allows tracking bad data in catalog without blocking parse/sync
+- User-facing error: "Circular prerequisite detected: COMP1000 → COMP2000 → COMP1000"
+
+**Implementation**:
+- Parser creates CoursePrerequisite records even if circular
+- Validator uses cycle detection algorithm (DFS/BFS) to identify loops
+- API response includes `circular_dependency: true` flag when detected
+
+### 2. Permission-Based Prerequisites
+
+**Decision**: Store as special prerequisite type, display-only (no validation)
+
+**Examples**: "Consent of instructor", "Consent of the academic unit"
+
+**Implementation**:
+```ruby
+# Migration:
+add_column :course_prerequisites, :special_requirement_text, :text
+change_column_null :course_prerequisites, :prerequisite_course_id, true
+
+# Enum expansion:
+enum prerequisite_type: {
+  standard: 0,
+  corequisite: 1,
+  permission: 2,        # NEW
+  placement_test: 3     # NEW
+}
+
+# Model validations:
+validates :prerequisite_course_id, presence: true, if: :standard_or_corequisite?
+validates :special_requirement_text, presence: true, if: :special_requirement?
+
+def standard_or_corequisite?
+  standard? || corequisite?
+end
+
+def special_requirement?
+  permission? || placement_test?
+end
+```
+
+**Data integrity**:
+- Standard/corequisite prerequisites MUST have `prerequisite_course_id` (references actual course)
+- Permission/placement prerequisites MUST have `special_requirement_text` (no course reference)
+- Validates at model level to prevent orphaned records
+
+**Parser behavior**:
+- Detect text matching `/consent|permission/i`
+- Create `permission` type prerequisite with NULL `prerequisite_course_id`
+- Store raw text in `special_requirement_text`
+
+**Validator behavior**:
+- Skip validation for `permission` type prerequisites
+- Include in API response: `{ type: "permission", requirement: "Consent of instructor", validated: false }`
+- UI displays: "⚠️ Additional requirement: Consent of instructor (contact department)"
+
+### 3. Placement Test Prerequisites
+
+**Decision**: Store as special type, display-only (future validation possible)
+
+**Examples**: "MATH Placement", "MATH1000 or MATH Placement"
+
+**Implementation**:
+```ruby
+# Same schema as permission prerequisites
+# Parser detects /placement/i pattern
+# Stores as placement_test type
+```
+
+**Validator behavior**:
+- Skip programmatic validation (we don't have placement test scores in system)
+- Include in response: `{ type: "placement", requirement: "MATH Placement", validated: false }`
+- UI displays: "⚠️ May be satisfied by: MATH Placement exam (contact advising)"
+
+**Future enhancement**: If placement test scores get added to User model, can implement validation later
+
+### 4. Grade Boundary Cases
+
+**Decision**: Use standardized grade comparison logic
+
+**Edge cases**:
+- B- grade: Does it satisfy "B or better"? **No** - only B, A-, A, A+ satisfy
+- C+ grade: Does it satisfy "C or better"? **Yes** - C+ is higher than C
+- Pass/Fail courses: Store as P/F, don't satisfy grade requirements (requires actual letter grade)
+
+**Implementation**:
+```ruby
+# In PrerequisiteValidationService:
+GRADE_VALUES = {
+  "A+" => 13, "A" => 12, "A-" => 11,
+  "B+" => 10, "B" => 9, "B-" => 8,
+  "C+" => 7, "C" => 6, "C-" => 5,
+  "D+" => 4, "D" => 3, "D-" => 2,
+  "F" => 1
+}
+
+def meets_grade_requirement?(user_grade, required_grade)
+  GRADE_VALUES[user_grade] >= GRADE_VALUES[required_grade]
+end
+```
+
+---
+
+## System Architecture
+
+### Database Schema (Task #1 - Completed)
+
+**CoursePrerequisite Model**
+```ruby
+# From Task #1:
+class CoursePrerequisite < ApplicationRecord
+  belongs_to :course
+  belongs_to :prerequisite_course, class_name: 'Course'
+
+  enum prerequisite_type: { standard: 0, corequisite: 1 }
+  enum operator: { and: 0, or: 1 }
+
+  # minimum_grade: string (A, B, C, D, or nil)
+  # group_id: integer (for grouping OR clauses)
+end
+```
+
+**Note**: The schema supports:
+- Multiple prerequisites per course
+- AND/OR logic via `operator` enum and `group_id`
+- Grade requirements via `minimum_grade`
+- Corequisites via `prerequisite_type` enum
+
+### Service Layer Design
+
+#### 1. CatalogScraperService
+
+**Purpose**: Scrape course descriptions from catalog.wit.edu
+
+**Key Methods**:
+```ruby
+class CatalogScraperService < ApplicationService
+  def initialize(department_code)
+    @department_code = department_code
+  end
+
+  def call
+    # Scrape all courses for department
+    # Returns array of {course_code:, title:, description:, prerequisite_text:}
+  end
+
+  private
+
+  def fetch_page
+    # HTTP request with error handling
+  end
+
+  def parse_courses(html)
+    # Extract course blocks
+  end
+
+  def extract_prerequisite_text(course_node)
+    # Find <em> tag containing "Prerequisite:" or "Corequisite:"
+  end
+end
+```
+
+**Error Handling**:
+- HTTP errors (404, timeout, etc.) → log and raise
+- HTML structure changes → Sentry alert (like DegreeAuditParserService)
+- Invalid department codes → raise validation error
+
+**Background Job**: `CatalogScraperJob.perform_later(department_code)`
+
+#### 2. PrerequisiteParserService
+
+**Purpose**: Parse prerequisite text into structured data for CoursePrerequisite records
+
+**Key Methods**:
+```ruby
+class PrerequisiteParserService < ApplicationService
+  def initialize(prerequisite_text, course:)
+    @prerequisite_text = prerequisite_text
+    @course = course
+  end
+
+  def call
+    # Parse text and create/update CoursePrerequisite records
+    # Returns array of CoursePrerequisite objects
+  end
+
+  private
+
+  def extract_corequisites
+    # Parse "Corequisite: MATH1000"
+  end
+
+  def extract_prerequisites
+    # Parse prerequisite logic
+  end
+
+  def parse_logical_structure
+    # Handle AND/OR logic with semicolons
+    # Algorithm:
+    # 1. Split by semicolons (high precedence AND groups)
+    # 2. Within each group, split by " and " or ", "
+    # 3. Within each AND clause, split by " or "
+    # 4. Assign group_id for each OR clause
+  end
+
+  def extract_grade_requirement(text)
+    # Regex: /completed with a grade of ([A-D])/
+  end
+
+  def extract_course_codes(text)
+    # Regex: /[A-Z]{4}[0-9]{4}/
+  end
+
+  def find_or_create_prerequisite_course(course_code)
+    # Look up Course by code or create placeholder
+  end
+end
+```
+
+**Parsing Algorithm**:
+
+Example: "COMP1050; MATH2300 or MATH2800"
+
+1. Split by semicolon → ["COMP1050", "MATH2300 or MATH2800"]
+2. Group 1 (ID: 1):
+   - COMP1050 (operator: and, group_id: 1)
+3. Group 2 (ID: 2):
+   - MATH2300 (operator: or, group_id: 2)
+   - MATH2800 (operator: or, group_id: 2)
+
+**Validation**: SQL: `(group_id=1 AND ...) AND (group_id=2 OR ...)`
+
+#### 3. PrerequisiteValidationService
+
+**Purpose**: Check if user has met prerequisites for a course
+
+**Key Methods**:
+```ruby
+class PrerequisiteValidationService < ApplicationService
+  def initialize(course:, user:)
+    @course = course
+    @user = user
+  end
+
+  def call
+    # Check all prerequisites
+    # Returns { eligible: true/false, unmet_prerequisites: [...], details: {...} }
+  end
+
+  private
+
+  def user_completed_courses
+    # Get user's completed courses with grades
+    # From UserCourse model (Task #1)
+  end
+
+  def check_prerequisite(prerequisite)
+    # Verify user has completed course with minimum grade
+  end
+
+  def check_prerequisite_group(group_id)
+    # For OR groups: at least one must be met
+    # For AND groups: all must be met
+  end
+
+  def check_corequisites
+    # Verify concurrent enrollment in current term
+  end
+end
+```
+
+**Response Format**:
+```json
+{
+  "eligible": false,
+  "unmet_prerequisites": [
+    {
+      "course_code": "MATH2300",
+      "minimum_grade": "C",
+      "status": "not_taken"
+    },
+    {
+      "course_code": "COMP1050",
+      "minimum_grade": null,
+      "status": "grade_too_low",
+      "user_grade": "D"
+    }
+  ],
+  "details": {
+    "groups": [
+      {"group_id": 1, "met": true},
+      {"group_id": 2, "met": false}
+    ]
+  }
+}
+```
+
+### API Layer
+
+#### API::PrerequisitesController
+
+**Endpoints**:
+
+1. **GET /api/courses/:id/prerequisites**
+   - Returns prerequisite tree for course
+   - Response includes all prerequisites with AND/OR logic
+   - Authorization: Any authenticated user
+
+2. **POST /api/courses/:id/check_eligibility**
+   - Checks if current user meets prerequisites
+   - Returns eligibility status and unmet requirements
+   - Authorization: User must own the check (checking own eligibility)
+
+**Controller Design**:
+```ruby
+class Api::PrerequisitesController < Api::BaseController
+  before_action :authenticate_user!
+  before_action :set_course
+
+  def index
+    # GET /api/courses/:id/prerequisites
+    prerequisites = @course.course_prerequisites
+                           .includes(:prerequisite_course)
+                           .order(:group_id, :operator)
+
+    render json: PrerequisiteSerializer.new(prerequisites).serializable_hash
+  end
+
+  def check_eligibility
+    # POST /api/courses/:id/check_eligibility
+    authorize @course, :check_prerequisite?
+
+    result = PrerequisiteValidationService.call(course: @course, user: current_user)
+
+    render json: result
+  end
+
+  private
+
+  def set_course
+    @course = Course.find(params[:id])
+  end
+end
+```
+
+### Background Jobs
+
+#### 1. CatalogScraperJob
+
+**Purpose**: Periodically scrape all departments to keep prerequisites up-to-date
+
+**Schedule**: Nightly (via cron or recurring job)
+
+```ruby
+class CatalogScraperJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Department.pluck(:code).each do |dept_code|
+      courses = CatalogScraperService.call(dept_code)
+
+      courses.each do |course_data|
+        course = Course.find_or_initialize_by(code: course_data[:course_code])
+        course.update!(
+          title: course_data[:title],
+          description: course_data[:description]
+        )
+
+        if course_data[:prerequisite_text].present?
+          PrerequisiteParserService.call(
+            course_data[:prerequisite_text],
+            course: course
+          )
+        end
+      end
+    end
+  end
+end
+```
+
+#### 2. PrerequisiteSyncJob (Optional)
+
+**Purpose**: Re-parse prerequisites for a single course (for manual updates)
+
+---
+
+## Testing Strategy
+
+**Total Estimated Coverage**: ~1,700 lines of test code (more complex than Task #2's 1,243 lines)
+
+### Testing Workflow (Priority Order)
+
+1. **Parser tests FIRST** - Core logic foundation
+2. **Validator tests** - Depends on parser output
+3. **Scraper tests** - Can develop in parallel
+4. **API request specs** - Integration layer
+5. **Integration tests** - Full flow validation
+
+### Testing Priority Levels
+
+**HIGH PRIORITY** (catches critical bugs):
+- Circular dependency detection
+- Grade boundary cases (B- vs "B or better")
+- Transfer credits handling
+- Admin authorization (all 4 access levels)
+- Advisory locks for concurrent scraping
+
+**MEDIUM PRIORITY** (edge cases):
+- Permission/placement parsing
+- Character encoding issues
+- Self-referencing prerequisites
+- N+1 query prevention
+
+**LOW PRIORITY** (nice-to-have):
+- Unicode character handling
+- Multiple whitespace variations
+- Performance optimization tests
+
+---
+
+### 1. Service Specs
+
+#### **CatalogScraperService** (`spec/services/catalog_scraper_service_spec.rb`)
+
+**Estimated: 200+ lines**
+
+**Core Functionality**:
+- ✅ Successful scraping with VCR cassettes
+- ✅ HTTP error handling (404, 500, timeout)
+- ✅ HTML structure changes (Sentry alerts)
+- ✅ Invalid department codes
+- ✅ Course extraction accuracy
+- ✅ Prerequisite text extraction
+
+**Additional Scenarios** (from test coverage review):
+- **Rate limiting/politeness delays** - Verify delays between requests
+- **Partial HTML extraction** - Some courses parse, others fail
+- **Empty department** - Department code valid but has no courses
+- **Redirect handling** - HTTP 301/302 responses
+- **Character encoding issues** - Non-UTF8 characters in descriptions
+- **Multiple prerequisite blocks** - Edge case: duplicate `<em>` tags per course
+- **VCR cassette maintenance** - Instructions for updating cassettes
+
+---
+
+#### **PrerequisiteParserService** (`spec/services/prerequisite_parser_service_spec.rb`)
+
+**Estimated: 400+ lines (most complex service)**
+
+**Core Functionality**:
+- ✅ Simple prerequisites (single course)
+- ✅ AND logic (multiple courses)
+- ✅ OR logic (alternative courses)
+- ✅ Mixed AND/OR with semicolons
+- ✅ Grade requirements parsing
+- ✅ Corequisites parsing
+- ✅ Invalid course codes (placeholder creation)
+- ✅ Idempotency (re-parsing same text)
+
+**Edge Cases**:
+- ✅ Empty prerequisite text
+- ✅ Malformed text
+- ✅ Non-course prerequisites ("permission", "placement")
+
+**Additional Scenarios** (from test coverage review):
+- **Circular dependencies** - Course A requires B, B requires A (store, don't reject)
+- **Self-referencing prerequisites** - Course requires itself (detect as invalid)
+- **Case sensitivity** - "COMP1000" vs "comp1000" normalization
+- **Whitespace variations** - Extra spaces, tabs, newlines
+- **Orphaned course codes** - Prerequisites reference non-existent courses
+- **Multiple grade requirements** - "MATH2100 with B and COMP1000 with C"
+- **Nested logic edge case** - Unexpected parentheses (graceful handling)
+- **Unicode/special characters** - Course codes with unusual characters
+- **Group ID assignment consistency** - Same structure → same group_id pattern
+- **Performance with complex prerequisites** - Course with 10+ groups
+- **Permission-based prerequisites** - "Consent of instructor" → permission type
+- **Placement test prerequisites** - "MATH Placement" → placement_test type
+
+**Complex Test Case Example**:
+```
+"COMP1050; MATH2300 or MATH2800; PHYS2000 completed with a grade of B or better; Consent of instructor"
+```
+Expected output:
+- Group 1: COMP1050 (AND)
+- Group 2: MATH2300 OR MATH2800
+- Group 3: PHYS2000 with grade B requirement
+- Group 4: Permission type (special_requirement_text)
+
+---
+
+#### **PrerequisiteValidationService** (`spec/services/prerequisite_validation_service_spec.rb`)
+
+**Estimated: 300+ lines**
+
+**Core Functionality**:
+- ✅ User meets all prerequisites
+- ✅ User missing prerequisites
+- ✅ User has insufficient grade
+- ✅ OR group scenarios (one met, none met)
+- ✅ AND group scenarios
+- ✅ Corequisite validation
+
+**Edge Cases**:
+- ✅ No prerequisites
+- ✅ User has no completed courses
+
+**Additional Scenarios** (from test coverage review):
+- **Transfer credits** - User completed equivalent course at another institution
+- **Grade boundary cases** - User has B-, "B or better" required (not satisfied)
+- **Grade boundary cases** - User has C+, "C or better" required (satisfied)
+- **In-progress courses** - User currently enrolled, not yet completed
+- **Withdrawn courses** - User withdrew with W grade (doesn't satisfy)
+- **Course retakes** - User failed then passed, use highest grade
+- **Multiple prerequisite paths** - OR group with 3+ options, user meets 2
+- **Empty user course history** - Brand new student (no courses)
+- **Concurrent corequisite validation** - Two courses are each other's corequisites
+- **Partial group completion** - Which specific courses are missing?
+- **Permission-based prerequisites** - Skip validation, include in response
+- **Placement test prerequisites** - Skip validation, include in response
+- **Circular dependency detection** - Detect cycle and return error
+- **Self-referencing prerequisite** - Course requires itself (invalid)
+
+**Grade Comparison Test Matrix**:
+```
+User Grade | Required Grade | Expected Result
+-----------|---------------|----------------
+A          | B or better   | ✅ Satisfied
+B-         | B or better   | ❌ Not satisfied
+C+         | C or better   | ✅ Satisfied
+C          | C or better   | ✅ Satisfied
+C-         | C or better   | ❌ Not satisfied
+P (Pass)   | B or better   | ❌ Not satisfied (no letter grade)
+```
+
+---
+
+### 2. Request Specs
+
+#### **API::PrerequisitesController** (`spec/requests/api/prerequisites_spec.rb`)
+
+**Estimated: 400+ lines (similar to Task #2 degree audit specs)**
+
+**GET /api/courses/:id/prerequisites**:
+- ✅ Valid course with prerequisites
+- ✅ Course with no prerequisites
+- ✅ Course not found (404)
+- ✅ Authentication required
+- ✅ Response format validation
+- **Complex prerequisite tree** - Course with 5+ groups, verify JSON structure
+- **Corequisites vs prerequisites** - Response differentiates types
+- **Special prerequisites** - Permission/placement types in response
+- **Pagination** - If prerequisite list is very long (unlikely)
+
+**POST /api/courses/:id/check_eligibility**:
+- ✅ User eligible
+- ✅ User not eligible (unmet prerequisites)
+- ✅ Authorization (users check own eligibility)
+- ✅ Response includes unmet requirements details
+- **Admin checking another user** - Should be allowed per authorization.md
+- **Partially eligible** - User meets some groups but not all
+- **User exceeds requirements** - User has A but only C required
+- **Multiple unmet prerequisites** - Response lists ALL unmet
+- **User has in-progress courses** - How does it affect eligibility?
+- **Response performance** - Verify N+1 query prevention
+- **Circular dependency response** - Returns circular_dependency flag
+- **Special prerequisites in response** - Permission/placement with validated: false
+
+**OpenAPI Documentation**:
+- ✅ Tag with `:openapi` for automatic API docs generation
+- ✅ Document request/response schemas
+- ✅ Include example responses
+
+**Response Format Example**:
+```json
+{
+  "eligible": false,
+  "unmet_prerequisites": [
+    {
+      "course_code": "MATH2300",
+      "minimum_grade": "C",
+      "status": "not_taken"
+    }
+  ],
+  "special_requirements": [
+    {
+      "type": "permission",
+      "requirement": "Consent of instructor",
+      "validated": false
+    }
+  ],
+  "circular_dependency": false,
+  "details": {
+    "groups": [
+      {"group_id": 1, "met": true},
+      {"group_id": 2, "met": false}
+    ]
+  }
+}
+```
+
+---
+
+### 3. Policy Specs
+
+#### **CoursePolicy** (`spec/policies/course_policy_spec.rb`)
+
+**Estimated: 60+ lines**
+
+**check_prerequisite? Permission**:
+- ✅ All authenticated users can check prerequisites
+- **Test all 4 access levels** (user/admin/super_admin/owner) per authorization.md
+- **Unauthenticated user** - Should be denied
+- **Admin checking ANY user's eligibility** - Should be allowed
+- **User checking another user's eligibility** - Should be denied (own resources only)
+
+**Access Level Matrix**:
+```
+Action                          | user | admin | super_admin | owner
+-------------------------------|------|-------|-------------|-------
+View course prerequisites       |  ✅  |  ✅   |     ✅      |  ✅
+Check own eligibility           |  ✅  |  ✅   |     ✅      |  ✅
+Check another user's eligibility|  ❌  |  ✅   |     ✅      |  ✅
+```
+
+---
+
+### 4. Job Specs
+
+#### **CatalogScraperJob** (`spec/jobs/catalog_scraper_job_spec.rb`)
+
+**Estimated: 150+ lines**
+
+**Core Functionality**:
+- ✅ Enqueues correctly
+- ✅ Calls CatalogScraperService for each department
+- ✅ Creates/updates courses
+- ✅ Triggers PrerequisiteParserService
+
+**Additional Scenarios** (from test coverage review):
+- **Job failure handling** - One department fails, continue with others
+- **Partial failure** - Some courses succeed, some fail
+- **Idempotency** - Running job twice doesn't duplicate data
+- **Monitoring/alerting** - Verify Sentry notifications on repeated failures
+- **Job timeout** - What if scraping takes too long?
+- **Database transaction handling** - Rollback on errors?
+- **Performance with 20+ departments** - Job duration tracking
+- **Advisory lock acquisition** - Prevent concurrent job execution
+
+---
+
+### 5. Integration Tests
+
+#### **Full Prerequisite Flow** (`spec/integration/prerequisite_flow_spec.rb`)
+
+**Estimated: 200+ lines**
+
+**Core Flows**:
+- ✅ Scrape → Parse → Validate end-to-end
+- ✅ Verify CoursePrerequisite records created correctly
+- ✅ Verify user eligibility checks work with real data
+
+**Additional Scenarios** (from test coverage review):
+- **Multi-course prerequisite chain** - A requires B requires C, user has C
+- **User completes prerequisite then checks eligibility** - Cache invalidation
+- **Prerequisite change detection** - Catalog updates, user's eligibility changes
+- **Concurrent user checks** - Multiple users checking same course
+- **Full semester registration flow** - User checks 4 courses, validates all
+- **Transfer student scenario** - User has transfer credits, checks upper-level courses
+- **Complex prerequisite tree traversal** - 5+ levels deep
+- **Circular dependency handling** - Detection and error response
+
+---
+
+### Performance Testing
+
+Add RSpec benchmark expectations:
+```ruby
+expect { parser_service.call }.to perform_under(100).ms
+expect { validation_service.call }.to perform_under(200).ms
+expect { api_endpoint }.to perform_under(500).ms
+```
+
+**Performance Targets**:
+- Parser: Handle 50+ prerequisite courses in <100ms
+- Validation: Check 10+ prerequisite groups in <200ms
+- API endpoint: Respond in <500ms for complex prerequisites
+- Background job: Process 1 department in <30 seconds
+
+---
+
+### Mock/Stub Strategy
+
+1. **CatalogScraperService**:
+   - Use **VCR cassettes** for real HTTP interactions
+   - Mock HTTP errors (timeout, 404, 500) to avoid actual failures
+   - Test against **frozen HTML fixtures** to detect structure changes
+
+2. **PrerequisiteParserService**:
+   - Use **real Course objects** from FactoryBot
+   - Test prerequisite creation in **database** to verify associations
+   - Mock Sentry for error notification tests
+
+3. **PrerequisiteValidationService**:
+   - Use **real UserCourse records** from FactoryBot
+   - Build complete user course histories with factories
+   - Don't mock validation logic (test actual algorithm)
+
+4. **API Controllers**:
+   - Use **real database records** via FactoryBot
+   - Mock background jobs (don't actually enqueue during tests)
+   - Use **request specs** (not controller specs) for full stack testing
+
+---
+
+### Critical Testing Notes
+
+1. **VCR cassettes MUST be committed** - So CI can run without hitting catalog.wit.edu
+2. **Test fixtures for all prerequisite patterns** - Don't rely only on live data
+3. **Policy specs MUST test all 4 access levels** - Per authorization.md patterns
+4. **Request specs MUST have :openapi tag** - For automatic API doc generation
+5. **Advisory lock tests critical** - Prevent concurrent scraping
+6. **Grade comparison tests exhaustive** - Cover all boundary cases (B-, C+, etc.)
+7. **Circular dependency detection** - Use DFS/BFS algorithm, test thoroughly
+
+---
+
+## Implementation Plan (After PR #344 and #346 merge)
+
+### Phase 1: Scraper (Week 1)
+1. Create `CatalogScraperService`
+2. Write service specs with VCR cassettes
+3. Handle HTTP errors and structure changes
+4. Create `CatalogScraperJob`
+5. Write job specs
+
+### Phase 2: Parser (Week 1-2)
+1. Create `PrerequisiteParserService`
+2. Implement logical structure parsing algorithm
+3. Handle all prerequisite patterns (AND/OR/mixed)
+4. Parse grade requirements and corequisites
+5. Write comprehensive service specs (15+ scenarios)
+
+### Phase 3: Validator (Week 2)
+1. Create `PrerequisiteValidationService`
+2. Implement group-based validation logic
+3. Check user's completed courses and grades
+4. Handle corequisites validation
+5. Write service specs (10+ scenarios)
+
+### Phase 4: API (Week 2)
+1. Create `Api::PrerequisitesController`
+2. Implement GET /api/courses/:id/prerequisites
+3. Implement POST /api/courses/:id/check_eligibility
+4. Add Pundit authorization
+5. Write request specs with OpenAPI generation (10+ scenarios)
+
+### Phase 5: Jobs & Scheduling (Week 2)
+1. Set up recurring CatalogScraperJob (nightly)
+2. Add monitoring for job failures
+3. Test job execution
+
+### Phase 6: Integration & Documentation (Week 2)
+1. End-to-end integration tests
+2. Update docs/prerequisite-system/README.md
+3. Document API endpoints in API docs
+4. Add prerequisite UI badge logic (frontend task)
+
+---
+
+## Implementation Decisions (Resolved)
+
+1. **Circular Dependencies**: ✅ **RESOLVED**
+   - Store at parse time, detect and warn at validation time
+   - Validator uses cycle detection algorithm (DFS/BFS)
+   - API response includes `circular_dependency: true` flag
+
+2. **Permission-Based Prerequisites**: ✅ **RESOLVED**
+   - Store as `permission` type with `special_requirement_text`
+   - Skip validation, display to user with `validated: false`
+   - UI shows: "⚠️ Additional requirement: Consent of instructor"
+
+3. **Placement Test Prerequisites**: ✅ **RESOLVED**
+   - Store as `placement_test` type with `special_requirement_text`
+   - Skip validation (no placement scores in system)
+   - Future enhancement: Add validation if scores added to User model
+
+4. **Grade Boundary Cases**: ✅ **RESOLVED**
+   - Use GRADE_VALUES hash with numeric comparison
+   - B- does NOT satisfy "B or better" (only B, A-, A, A+)
+   - C+ DOES satisfy "C or better"
+   - Pass/Fail courses don't satisfy grade requirements
+
+5. **Schema Changes**: ✅ **RESOLVED**
+   - Add `special_requirement_text` text column
+   - Expand `prerequisite_type` enum: standard/corequisite/permission/placement_test
+
+---
+
+## Open Questions (Still To Resolve)
+
+1. **Department List**: How do we get the list of all department codes?
+   - Option A: Hardcode based on WIT's departments
+   - Option B: Scrape department list from catalog homepage
+   - **Recommendation**: Start with hardcoded list, add scraping later
+
+2. **Placeholder Courses**: When parsing prerequisites, should we create Course records for courses that don't exist in our database?
+   - **Recommendation**: Yes, create placeholder records with `scraped: false` flag. Background job will fill in details later.
+
+3. **Grade Data Source**: Where do we get user's grades for completed courses?
+   - From `UserCourse` model (Task #1) - has `grade` field
+   - Assumes grades are scraped from LeopardWeb
+
+4. **Prerequisite Change Detection**: Should we track when prerequisites change?
+   - **Recommendation**: Store `prerequisites_updated_at` on Course model
+   - Alert users if prerequisites change for courses they're planning to take
+
+5. **Corequisite Validation Timing**: When do we validate corequisites?
+   - At registration time (checking if user is also enrolling in corequisite)
+   - Requires access to user's planned courses for upcoming term
+   - **Recommendation**: Implement after CRN generation (Task #5) is complete
+
+6. **Transfer Credit Handling**: How to determine if transfer credit satisfies prerequisite?
+   - Requires course equivalency data (not in current schema)
+   - **Recommendation**: Phase 2 enhancement after MVP
+
+---
+
+## Performance Considerations
+
+1. **Scraping Frequency**:
+   - Prerequisites rarely change (maybe once per semester)
+   - Nightly scraping is sufficient
+   - Add manual trigger for emergency updates
+
+2. **Validation Caching**:
+   - Eligibility checks could be cached per user/course pair
+   - Cache invalidation: when user's completed courses change
+   - **Recommendation**: Implement caching if validation becomes slow
+
+3. **Database Indexes**:
+   - Index on `course_prerequisites.group_id` for efficient grouping
+   - Index on `course_prerequisites.course_id` for prerequisite lookup
+   - **Recommendation**: Add in migration
+
+---
+
+## Security Considerations
+
+1. **Authorization**:
+   - All users can view prerequisites (public data)
+   - Users can only check their own eligibility (user-owned data)
+   - Admins can check eligibility for any user (for support)
+
+2. **Input Validation**:
+   - Validate course IDs in API requests
+   - Sanitize scraped HTML to prevent XSS
+   - Validate department codes before scraping
+
+3. **Rate Limiting**:
+   - Scraping: Use delays between requests to avoid overloading catalog.wit.edu
+   - API: Use Rack::Attack to prevent abuse of eligibility checks
+
+4. **Data Privacy**:
+   - User's completed courses and grades are sensitive
+   - Only expose to authorized users (self or admin)
+   - Don't include in API responses unless necessary
+
+---
+
+## Future Enhancements (Post-MVP)
+
+1. **Prerequisite Recommendations**: Suggest course sequences to meet prerequisites
+2. **Prerequisite Visualization**: Graph view of prerequisite chains
+3. **Smart Registration Planning**: Automatically plan course sequences across semesters
+4. **Prerequisite Waiver Tracking**: Track when users get prerequisite waivers
+5. **Historical Prerequisites**: Track prerequisite changes over time
+6. **Transfer Credit Integration**: Validate prerequisites against transfer credits
+
+---
+
+## References
+
+- **Database Schema**: Task #1 (PR #344)
+- **Existing Service Patterns**: `app/services/google_calendar_service.rb`, `app/services/degree_audit_parser_service.rb`
+- **API Patterns**: `app/controllers/api/degree_audits_controller.rb`
+- **Authorization Patterns**: `docs/authorization.md`
+- **Testing Patterns**: `spec/services/degree_audit_parser_service_spec.rb`
+- **Job Patterns**: `app/jobs/google_calendar_sync_job.rb`


### PR DESCRIPTION
## Summary

- Extracts inline JSON-building logic from API controllers into dedicated PORO serializer objects in `app/serializers/`
- Adds `PreferenceSerializable` concern to share reminder/color helper logic across serializers and `ApiController`
- Removes now-redundant private `preference_json`, `event_preference_json`, `serialize_event`, `term_json`, and `group_meeting_times` methods from controllers

## Serializers created

| Serializer | Replaces |
|---|---|
| `TermSerializer` | `MiscController#term_json` |
| `FacultySerializer` | Inline faculty hash in `UsersController` |
| `CalendarPreferenceSerializer` | `CalendarPreferencesController#preference_json` |
| `EventPreferenceSerializer` | `EventPreferencesController#event_preference_json` |
| `UniversityCalendarEventSerializer` | `UniversityCalendarEventsController#serialize_event` |
| `MeetingTimeSerializer` | Per-item logic in `UsersController#group_meeting_times` |
| `EnrolledCourseSerializer` | Inline enrollment loop in `UsersController#get_processed_events_by_term` |
| `concerns/PreferenceSerializable` | `ApiController` color/reminder helpers |

## Test plan
- [ ] Verify `GET /api/misc/current_terms` still returns correct term shape
- [ ] Verify `GET /api/calendar_preferences` returns correct preference shape
- [ ] Verify `GET /api/meeting_times/:id/preference` returns correct shape
- [ ] Verify `GET /api/university_calendar_events` returns correct event shape
- [ ] Verify `GET /api/user/processed_events` returns correct course/meeting time shape

Closes #350

PR assisted by Claude