### PR TITLE
feat: transfer credit database integration (#342)

### DIFF
--- a/app/controllers/admin/transfer_equivalencies_controller.rb
+++ b/app/controllers/admin/transfer_equivalencies_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Admin
+  class TransferEquivalenciesController < Admin::ApplicationController
+    def index
+      @equivalencies = policy_scope(Transfer::Equivalency)
+                       .includes(transfer_course: :university, wit_course: :term)
+                       .order(created_at: :desc)
+
+      if params[:search].present?
+        search = "%#{params[:search]}%"
+        @equivalencies = @equivalencies.joins(transfer_course: :university)
+                                       .where(
+                                         "transfer_courses.course_code ILIKE :q OR " \
+                                         "transfer_courses.course_title ILIKE :q OR " \
+                                         "transfer_universities.name ILIKE :q",
+                                         q: search
+                                       )
+      end
+
+      if params[:university].present?
+        @equivalencies = @equivalencies.joins(transfer_course: :university)
+                                       .where(transfer_universities: { id: params[:university] })
+      end
+
+      @stats = {
+        universities: Transfer::University.count,
+        transfer_courses: Transfer::Course.count,
+        equivalencies: Transfer::Equivalency.count,
+        active_equivalencies: Transfer::Equivalency.active.count
+      }
+
+      @universities = Transfer::University.order(:name)
+      @equivalencies = @equivalencies.page(params[:page]).per(25)
+    end
+
+    def sync
+      authorize Transfer::Equivalency
+
+      TransferEquivalencySyncJob.perform_later
+      redirect_to admin_transfer_equivalencies_path, notice: "Transfer equivalency sync queued successfully."
+    end
+
+  end
+end

--- a/app/jobs/transfer_equivalency_sync_job.rb
+++ b/app/jobs/transfer_equivalency_sync_job.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class TransferEquivalencySyncJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Rails.logger.info "[TransferEquivalencySyncJob] Starting transfer equivalency sync"
+
+    result = Transfer::EquivalencySyncService.call
+
+    Rails.logger.info "[TransferEquivalencySyncJob] Sync completed: " \
+                      "#{result[:universities_synced]} universities, " \
+                      "#{result[:courses_synced]} courses, " \
+                      "#{result[:equivalencies_synced]} equivalencies synced"
+
+    if result[:errors].any?
+      Rails.logger.warn "[TransferEquivalencySyncJob] #{result[:errors].size} errors: #{result[:errors].first(5).join('; ')}"
+    end
+
+    result
+  end
+
+end

--- a/app/policies/transfer/equivalency_policy.rb
+++ b/app/policies/transfer/equivalency_policy.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Transfer
+  class EquivalencyPolicy < ApplicationPolicy
+    # Transfer equivalencies are public read - anyone can view
+    def index?
+      true
+    end
+
+    def show?
+      true
+    end
+
+    # Only admins can trigger sync
+    def sync?
+      admin?
+    end
+
+    class Scope < ApplicationPolicy::Scope
+      def resolve
+        scope.all
+      end
+
+    end
+
+  end
+end

--- a/app/services/admin/navigation_registry.rb
+++ b/app/services/admin/navigation_registry.rb
@@ -143,6 +143,14 @@ module Admin
         min_role: :admin,
         items: [
           {
+            id: :transfer_equivalencies,
+            title: "Transfer Equivalencies",
+            path: :admin_transfer_equivalencies_path,
+            icon: "arrows-right-left",
+            description: "View and sync transfer credit equivalencies",
+            keywords: ["transfer", "credits", "equivalency", "tes"]
+          },
+          {
             id: :course_catalog,
             title: "Course Catalog",
             path: :admin_course_catalog_path,

--- a/app/services/transfer/equivalency_sync_service.rb
+++ b/app/services/transfer/equivalency_sync_service.rb
@@ -1,0 +1,350 @@
+# frozen_string_literal: true
+
+module Transfer
+  class EquivalencySyncService < ApplicationService
+    require "faraday"
+    require "nokogiri"
+
+    TES_BASE_URL = "https://tes.collegesource.com/publicview/TES_publicview01.aspx"
+    TES_RID = "ff2d54be-fd79-43ae-ab65-0de2a31cad80"
+    USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+
+    def call
+      @results = { universities_synced: 0, courses_synced: 0, equivalencies_synced: 0, errors: [] }
+
+      Rails.logger.info "[TransferEquivalencySync] Starting sync from TES database"
+
+      begin
+        html = fetch_tes_page
+        equivalencies_data = parse_equivalencies(html)
+
+        if equivalencies_data.empty?
+          Rails.logger.warn "[TransferEquivalencySync] No equivalency data found on TES page"
+          @results[:errors] << "No equivalency data found - the TES page may require interactive session"
+          return @results
+        end
+
+        process_equivalencies(equivalencies_data)
+      rescue Faraday::Error => e
+        @results[:errors] << "Network error: #{e.message}"
+        Rails.logger.error "[TransferEquivalencySync] Network error: #{e.message}"
+      rescue => e
+        @results[:errors] << "Unexpected error: #{e.message}"
+        Rails.logger.error "[TransferEquivalencySync] Unexpected error: #{e.message}"
+        Rails.logger.error e.backtrace.first(5).join("\n")
+      end
+
+      Rails.logger.info "[TransferEquivalencySync] Completed: #{@results.except(:errors).inspect}"
+      @results
+    end
+
+    private
+
+    def fetch_tes_page
+      response = connection.get(TES_BASE_URL, rid: TES_RID)
+
+      unless response.success?
+        raise "TES page returned HTTP #{response.status}"
+      end
+
+      response.body
+    end
+
+    # Parse the equivalency grid from the TES page HTML.
+    # The TES page uses a GridView with id="gdvCourseEQ" containing equivalency rows.
+    # Each row has columns: checkbox, sending institution + course, receiving course, dates.
+    #
+    # If the main grid is not present (page says "not available" or requires postback),
+    # we fall back to parsing any available equivalency data from the page.
+    def parse_equivalencies(html)
+      doc = Nokogiri::HTML(html)
+      equivalencies = []
+
+      # Try the main equivalency grid
+      grid = doc.at_css("#gdvCourseEQ")
+      if grid
+        rows = grid.css("tr").drop(1) # skip header row
+        rows.each do |row|
+          data = parse_grid_row(row)
+          equivalencies << data if data
+        end
+        return equivalencies
+      end
+
+      # The TES page is an ASP.NET WebForms application that requires interactive
+      # postbacks to load equivalency data. If the grid is not found, attempt to
+      # perform a search postback to load data.
+      fetch_via_postback(doc)
+
+    end
+
+    def parse_grid_row(row)
+      cells = row.css("td")
+      return nil if cells.size < 4
+
+      # Typical TES grid columns:
+      # [checkbox] [sending institution + course info] [receiving/equivalent course] [dates/status]
+      sending_cell = cells[1]
+      receiving_cell = cells[2]
+
+      return nil unless sending_cell && receiving_cell
+
+      sending_info = parse_course_cell(sending_cell)
+      receiving_info = parse_course_cell(receiving_cell)
+
+      return nil unless sending_info && receiving_info
+
+      {
+        sending_institution: sending_info[:institution],
+        sending_course_code: sending_info[:course_code],
+        sending_course_title: sending_info[:course_title],
+        sending_credits: sending_info[:credits],
+        wit_course_code: receiving_info[:course_code],
+        wit_course_title: receiving_info[:course_title],
+        effective_date: parse_date_from_row(cells),
+        expiration_date: parse_expiration_from_row(cells)
+      }
+    end
+
+    def parse_course_cell(cell)
+      text = cell.text.strip
+      return nil if text.blank?
+
+      lines = text.split("\n").map(&:strip).compact_blank
+      return nil if lines.empty?
+
+      institution = nil
+      course_code = nil
+      course_title = nil
+      credits = nil
+
+      # Look for institution name (usually bold or in a span with class)
+      inst_el = cell.at_css(".institution_name, b, strong")
+      institution = inst_el&.text&.strip
+
+      # Parse course code and title from remaining text
+      lines.each do |line|
+        next if line == institution
+
+        if line.match?(/\A[A-Z]{2,6}\s*\d{3,4}/)
+          course_code = line
+        elsif line.match?(/\d+(\.\d+)?\s*credits?/i)
+          credits = line[/(\d+(?:\.\d+)?)/, 1]&.to_f
+        elsif course_code && course_title.nil?
+          course_title = line
+        end
+      end
+
+      # If we didn't find structured data, try a simpler parse
+      if course_code.nil? && lines.size >= 2
+        course_code = lines.first
+        course_title = lines[1] if lines.size > 1
+      end
+
+      return nil if course_code.blank?
+
+      {
+        institution: institution,
+        course_code: course_code,
+        course_title: course_title || course_code,
+        credits: credits
+      }
+    end
+
+    def parse_date_from_row(cells)
+      cells.each do |cell|
+        text = cell.text.strip
+        date = extract_date(text)
+        return date if date
+      end
+      nil
+    end
+
+    def parse_expiration_from_row(cells)
+      dates = []
+      cells.each do |cell|
+        text = cell.text.strip
+        date = extract_date(text)
+        dates << date if date
+      end
+      # Second date is typically the expiration
+      dates.size >= 2 ? dates[1] : nil
+    end
+
+    def extract_date(text)
+      if text.match?(/\d{1,2}\/\d{1,2}\/\d{4}/)
+        Date.strptime(text[/(\d{1,2}\/\d{1,2}\/\d{4})/, 1], "%m/%d/%Y")
+      end
+    rescue Date::Error
+      nil
+    end
+
+    def fetch_via_postback(doc)
+      # Extract ASP.NET form fields needed for postback
+      vstate = doc.at_css("#_VSTATE")&.[]("value")
+      viewstate = doc.at_css("#__VIEWSTATE")&.[]("value")
+      event_validation = doc.at_css("#__EVENTVALIDATION")&.[]("value")
+
+      return [] unless event_validation
+
+      # Perform a search postback to load all institutions' equivalencies
+      form_data = {
+        "_VSTATE"           => vstate.to_s,
+        "__VIEWSTATE"       => viewstate.to_s,
+        "__EVENTVALIDATION" => event_validation,
+        "__EVENTTARGET"     => "btnCourseEQSearch",
+        "__EVENTARGUMENT"   => "",
+        "rblEffectiveDate"  => "3", # Both active and inactive
+        "tbxCourseCode"     => "",
+        "rblCourseCodeType" => "3", # Both transfer and equivalent
+        "ddlRecordsPerPage" => "200",
+        "ddlSortListBy"     => "1"
+      }
+
+      response = connection.post("#{TES_BASE_URL}?rid=#{TES_RID}") do |req|
+        req.headers["Content-Type"] = "application/x-www-form-urlencoded"
+        req.body = URI.encode_www_form(form_data)
+      end
+
+      return [] unless response.success?
+
+      result_doc = Nokogiri::HTML(response.body)
+      grid = result_doc.at_css("#gdvCourseEQ")
+      return [] unless grid
+
+      equivalencies = []
+      rows = grid.css("tr").drop(1)
+      rows.each do |row|
+        data = parse_grid_row(row)
+        equivalencies << data if data
+      end
+
+      equivalencies
+    end
+
+    def process_equivalencies(equivalencies_data)
+      equivalencies_data.each do |data|
+        process_single_equivalency(data)
+      rescue => e
+        @results[:errors] << "Error processing #{data[:sending_course_code]}: #{e.message}"
+        Rails.logger.error "[TransferEquivalencySync] Error processing equivalency: #{e.message}"
+      end
+    end
+
+    def process_single_equivalency(data)
+      return if data[:sending_institution].blank?
+
+      university = find_or_create_university(data[:sending_institution])
+      return unless university
+
+      transfer_course = find_or_create_transfer_course(university, data)
+      return unless transfer_course
+
+      wit_course = find_wit_course(data[:wit_course_code])
+      unless wit_course
+        @results[:errors] << "WIT course not found for: #{data[:wit_course_code]}"
+        return
+      end
+
+      find_or_create_equivalency(transfer_course, wit_course, data)
+    end
+
+    def find_or_create_university(institution_name)
+      code = generate_university_code(institution_name)
+
+      university = Transfer::University.find_or_initialize_by(code: code)
+      if university.new_record?
+        university.name = institution_name
+        university.active = true
+        university.save!
+        @results[:universities_synced] += 1
+        Rails.logger.info "[TransferEquivalencySync] Created university: #{institution_name} (#{code})"
+      end
+
+      university
+    rescue ActiveRecord::RecordInvalid => e
+      @results[:errors] << "Failed to create university #{institution_name}: #{e.message}"
+      nil
+    end
+
+    def find_or_create_transfer_course(university, data)
+      course = Transfer::Course.find_or_initialize_by(
+        university: university,
+        course_code: data[:sending_course_code]
+      )
+
+      if course.new_record?
+        course.course_title = data[:sending_course_title] || data[:sending_course_code]
+        course.credits = data[:sending_credits]
+        course.active = true
+        course.save!
+        @results[:courses_synced] += 1
+      end
+
+      course
+    rescue ActiveRecord::RecordInvalid => e
+      @results[:errors] << "Failed to create transfer course #{data[:sending_course_code]}: #{e.message}"
+      nil
+    end
+
+    def find_wit_course(course_code)
+      return nil if course_code.blank?
+
+      # Parse subject and course number from code like "COMP 1000" or "COMP1000"
+      match = course_code.match(/\A([A-Z]+)\s*(\d+)\z/)
+      return nil unless match
+
+      subject_prefix = match[1]
+      course_number = match[2].to_i
+
+      # WIT courses store subject as full name with abbreviation in parens, e.g. "Computer Science (COMP)"
+      # Match by the abbreviation in parens and course_number
+      Course.where(course_number: course_number)
+            .where("subject LIKE ?", "%(#{subject_prefix})%")
+            .order(created_at: :desc)
+            .first
+    end
+
+    def find_or_create_equivalency(transfer_course, wit_course, data)
+      equivalency = Transfer::Equivalency.find_or_initialize_by(
+        transfer_course: transfer_course,
+        wit_course: wit_course
+      )
+
+      if equivalency.new_record?
+        equivalency.effective_date = data[:effective_date] || Date.current
+        equivalency.expiration_date = data[:expiration_date]
+        equivalency.save!
+        @results[:equivalencies_synced] += 1
+      end
+
+      equivalency
+    rescue ActiveRecord::RecordInvalid => e
+      @results[:errors] << "Failed to create equivalency: #{e.message}"
+      nil
+    end
+
+    def generate_university_code(name)
+      # Generate a short code from the institution name
+      # e.g. "Boston University" -> "BOSTON-UNIV"
+      words = name.gsub(/[^a-zA-Z\s]/, "").split
+      if words.size <= 2
+        words.map { |w| w.upcase[0..5] }.join("-")
+      else
+        "#{words.first(3).map { |w| w[0].upcase }.join}-#{words.first.upcase[0..3]}"
+      end
+    end
+
+    def connection
+      @connection ||= Faraday.new do |faraday|
+        faraday.headers["User-Agent"] = USER_AGENT
+        faraday.headers["Accept"] = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+        faraday.request :url_encoded
+        faraday.adapter Faraday.default_adapter
+        faraday.options.timeout = 30
+        faraday.options.open_timeout = 10
+      end
+    end
+
+  end
+end

--- a/app/views/admin/transfer_equivalencies/index.html.erb
+++ b/app/views/admin/transfer_equivalencies/index.html.erb
@@ -1,0 +1,128 @@
+<div class="container mx-auto px-2 pb-8">
+  <div class="flex justify-between items-center mb-6">
+    <h1 class="text-2xl font-bold">Transfer Equivalencies</h1>
+    <div class="flex gap-2">
+      <%= button_to "Sync Now", sync_admin_transfer_equivalencies_path, method: :post,
+          class: "glass-button px-4 py-2 rounded text-sm cursor-pointer inline-block" %>
+      <%= link_to "Back to Dashboard", admin_root_path,
+          class: "glass-button px-4 py-2 rounded text-sm cursor-pointer inline-block" %>
+    </div>
+  </div>
+
+  <% if flash[:notice] %>
+    <div class="mb-4 p-3 rounded bg-green-100 text-green-800 text-sm">
+      <%= flash[:notice] %>
+    </div>
+  <% end %>
+
+  <!-- Stats -->
+  <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+    <div class="bg-white shadow rounded-lg p-4 text-center" style="background: rgba(255, 255, 255, 0.6); backdrop-filter: blur(5px); border: 1px solid rgba(209, 55, 50, 0.3);">
+      <div class="text-2xl font-bold text-red-700"><%= @stats[:universities] %></div>
+      <div class="text-sm text-gray-600">Universities</div>
+    </div>
+    <div class="bg-white shadow rounded-lg p-4 text-center" style="background: rgba(255, 255, 255, 0.6); backdrop-filter: blur(5px); border: 1px solid rgba(209, 55, 50, 0.3);">
+      <div class="text-2xl font-bold text-red-700"><%= @stats[:transfer_courses] %></div>
+      <div class="text-sm text-gray-600">Transfer Courses</div>
+    </div>
+    <div class="bg-white shadow rounded-lg p-4 text-center" style="background: rgba(255, 255, 255, 0.6); backdrop-filter: blur(5px); border: 1px solid rgba(209, 55, 50, 0.3);">
+      <div class="text-2xl font-bold text-red-700"><%= @stats[:equivalencies] %></div>
+      <div class="text-sm text-gray-600">Total Equivalencies</div>
+    </div>
+    <div class="bg-white shadow rounded-lg p-4 text-center" style="background: rgba(255, 255, 255, 0.6); backdrop-filter: blur(5px); border: 1px solid rgba(209, 55, 50, 0.3);">
+      <div class="text-2xl font-bold text-red-700"><%= @stats[:active_equivalencies] %></div>
+      <div class="text-sm text-gray-600">Active Equivalencies</div>
+    </div>
+  </div>
+
+  <!-- Filters -->
+  <div class="mb-4">
+    <%= form_with(url: admin_transfer_equivalencies_path, method: :get, class: "flex gap-2") do |f| %>
+      <%= f.text_field :search,
+          value: params[:search],
+          placeholder: "Search by course code, title, or university...",
+          class: "glass-input flex-1 px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-opacity-50" %>
+      <%= f.select :university, @universities.map { |u| [u.name, u.id] },
+          { include_blank: "All Universities", selected: params[:university] },
+          class: "glass-input px-4 py-2 border border-gray-300 rounded-md shadow-sm" %>
+      <%= f.submit "Filter", class: "glass-button px-6 py-2 rounded cursor-pointer" %>
+      <% if params[:search].present? || params[:university].present? %>
+        <%= link_to "Clear", admin_transfer_equivalencies_path, class: "glass-button px-6 py-2 rounded inline-flex items-center" %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <!-- Equivalencies Table -->
+  <div class="bg-white shadow-lg rounded-lg overflow-hidden" style="background: rgba(255, 255, 255, 0.6); backdrop-filter: blur(5px); -webkit-backdrop-filter: blur(5px); border: 1px solid rgba(209, 55, 50, 0.3);">
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead style="background: rgba(255, 255, 255, 0.5);">
+          <tr>
+            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">
+              Sending Institution
+            </th>
+            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">
+              Transfer Course
+            </th>
+            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">
+              WIT Equivalent
+            </th>
+            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">
+              Effective Date
+            </th>
+            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">
+              Status
+            </th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200" style="background: rgba(255, 255, 255, 0.3);">
+          <% if @equivalencies.any? %>
+            <% @equivalencies.each do |equivalency| %>
+              <tr class="hover:bg-white/50 transition">
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 font-medium">
+                  <%= equivalency.transfer_course.university.name %>
+                </td>
+                <td class="px-6 py-4">
+                  <div class="text-sm text-gray-900 font-medium"><%= equivalency.transfer_course.course_code %></div>
+                  <div class="text-sm text-gray-500"><%= equivalency.transfer_course.course_title %></div>
+                </td>
+                <td class="px-6 py-4">
+                  <div class="text-sm text-gray-900 font-medium">
+                    <%= equivalency.wit_course.subject %> <%= equivalency.wit_course.course_number %>
+                  </div>
+                  <div class="text-sm text-gray-500"><%= equivalency.wit_course.title %></div>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
+                  <%= equivalency.effective_date.strftime("%b %d, %Y") %>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap">
+                  <% if equivalency.active? %>
+                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
+                      Active
+                    </span>
+                  <% else %>
+                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 text-red-800">
+                      Expired
+                    </span>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          <% else %>
+            <tr>
+              <td colspan="5" class="px-6 py-8 text-center text-sm text-gray-500">
+                No transfer equivalencies found. Click "Sync Now" to import from TES.
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+
+    <% if @equivalencies.respond_to?(:total_pages) && @equivalencies.total_pages > 1 %>
+      <div class="px-6 py-4 border-t border-gray-200" style="background: rgba(255, 255, 255, 0.4);">
+        <%= paginate @equivalencies %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -502,6 +502,12 @@ Rails.application.routes.draw do
       end
       resources :rmp_ratings, only: [:index]
 
+      resources :transfer_equivalencies, only: [:index] do
+        collection do
+          post :sync
+        end
+      end
+
       # Course catalog importer (admin utility)
       get "course_catalog", to: "course_catalog#index", as: :course_catalog
       post "course_catalog/import/:term_uid", to: "course_catalog#import", as: :course_catalog_import

--- a/lib/tasks/transfer.rake
+++ b/lib/tasks/transfer.rake
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+namespace :transfer do
+  desc "Sync transfer equivalency database from TES"
+  task sync_equivalencies: :environment do
+    puts "Syncing transfer equivalencies from TES..."
+    result = Transfer::EquivalencySyncService.call
+
+    puts "Results:"
+    puts "  Universities synced: #{result[:universities_synced]}"
+    puts "  Courses synced: #{result[:courses_synced]}"
+    puts "  Equivalencies synced: #{result[:equivalencies_synced]}"
+
+    if result[:errors].any?
+      puts "  Errors (#{result[:errors].size}):"
+      result[:errors].each { |e| puts "    - #{e}" }
+    end
+  end
+end

--- a/spec/jobs/transfer_equivalency_sync_job_spec.rb
+++ b/spec/jobs/transfer_equivalency_sync_job_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TransferEquivalencySyncJob do
+  include ActiveJob::TestHelper
+
+  describe "#perform" do
+    let(:sync_result) do
+      { universities_synced: 5, courses_synced: 10, equivalencies_synced: 8, errors: [] }
+    end
+
+    before do
+      allow(Transfer::EquivalencySyncService).to receive(:call).and_return(sync_result)
+    end
+
+    it "calls Transfer::EquivalencySyncService" do
+      expect(Transfer::EquivalencySyncService).to receive(:call)
+      described_class.new.perform
+    end
+
+    it "returns the sync result" do
+      result = described_class.new.perform
+      expect(result).to eq(sync_result)
+    end
+
+    context "when service returns errors" do
+      let(:sync_result) do
+        { universities_synced: 3, courses_synced: 5, equivalencies_synced: 2, errors: ["WIT course not found for: MATH 9999"] }
+      end
+
+      it "completes without raising" do
+        expect { described_class.new.perform }.not_to raise_error
+      end
+    end
+  end
+
+  describe "queue configuration" do
+    it "uses the default queue" do
+      expect(described_class.new.queue_name).to eq("default")
+    end
+  end
+
+  describe "enqueueing" do
+    it "can be enqueued" do
+      expect {
+        described_class.perform_later
+      }.to have_enqueued_job(described_class)
+    end
+  end
+end

--- a/spec/services/transfer/equivalency_sync_service_spec.rb
+++ b/spec/services/transfer/equivalency_sync_service_spec.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Transfer::EquivalencySyncService do
+  describe ".call" do
+    let(:service) { described_class.new }
+
+    # Sample TES page HTML with an equivalency grid
+    let(:tes_html_with_grid) do
+      <<~HTML
+        <html>
+        <body>
+          <table id="gdvCourseEQ">
+            <tr>
+              <th>Select</th>
+              <th>Sending Institution / Course</th>
+              <th>Receiving Course</th>
+              <th>Dates</th>
+            </tr>
+            <tr>
+              <td><input type="checkbox" /></td>
+              <td>
+                <b>Boston University</b>
+                <br/>CS 111
+                <br/>Intro to CS
+                <br/>3.0 credits
+              </td>
+              <td>
+                <br/>COMP 1000
+                <br/>Computer Science I
+              </td>
+              <td>01/15/2024</td>
+            </tr>
+            <tr>
+              <td><input type="checkbox" /></td>
+              <td>
+                <b>Northeastern University</b>
+                <br/>CS 2500
+                <br/>Fundamentals of CS
+                <br/>4.0 credits
+              </td>
+              <td>
+                <br/>COMP 2000
+                <br/>Computer Science II
+              </td>
+              <td>09/01/2023</td>
+            </tr>
+          </table>
+        </body>
+        </html>
+      HTML
+    end
+
+    let(:tes_html_empty) do
+      <<~HTML
+        <html>
+        <body>
+          <span id="lblPubViewHeader">
+            <b>This page is not available.</b>
+          </span>
+        </body>
+        </html>
+      HTML
+    end
+
+    before do
+      stub_request(:get, /tes\.collegesource\.com/)
+        .to_return(status: 200, body: tes_html_with_grid)
+    end
+
+    context "when TES page has equivalency grid" do
+      let!(:wit_course_1) do
+        create(:course, subject: "Computer Science (COMP)", course_number: 1000)
+      end
+
+      let!(:wit_course_2) do
+        create(:course, subject: "Computer Science (COMP)", course_number: 2000)
+      end
+
+      it "returns result hash with sync counts" do
+        result = described_class.call
+
+        expect(result).to include(
+          universities_synced: a_value >= 0,
+          courses_synced: a_value >= 0,
+          equivalencies_synced: a_value >= 0,
+          errors: an_instance_of(Array)
+        )
+      end
+
+      it "creates university records" do
+        expect { described_class.call }.to change(Transfer::University, :count).by(2)
+      end
+
+      it "creates transfer course records" do
+        expect { described_class.call }.to change(Transfer::Course, :count).by(2)
+      end
+
+      it "creates equivalency records linking to WIT courses" do
+        expect { described_class.call }.to change(Transfer::Equivalency, :count).by(2)
+      end
+
+      it "does not create duplicate records on re-run" do
+        described_class.call
+        expect { described_class.call }.not_to change(Transfer::University, :count)
+        expect { described_class.call }.not_to change(Transfer::Course, :count)
+        expect { described_class.call }.not_to change(Transfer::Equivalency, :count)
+      end
+    end
+
+    context "when WIT course is not found" do
+      it "records error for missing WIT course" do
+        result = described_class.call
+
+        expect(result[:errors]).to include(a_string_matching(/WIT course not found/))
+      end
+
+      it "does not create equivalency without WIT course" do
+        expect { described_class.call }.not_to change(Transfer::Equivalency, :count)
+      end
+    end
+
+    context "when TES page has no grid" do
+      before do
+        stub_request(:get, /tes\.collegesource\.com/)
+          .to_return(status: 200, body: tes_html_empty)
+        # Also stub the POST for postback attempt
+        stub_request(:post, /tes\.collegesource\.com/)
+          .to_return(status: 200, body: tes_html_empty)
+      end
+
+      it "returns empty results with an error" do
+        result = described_class.call
+
+        expect(result[:equivalencies_synced]).to eq(0)
+        expect(result[:errors]).to include(a_string_matching(/No equivalency data found/))
+      end
+    end
+
+    context "when network error occurs" do
+      before do
+        stub_request(:get, /tes\.collegesource\.com/)
+          .to_raise(Faraday::ConnectionFailed.new("Connection refused"))
+      end
+
+      it "handles network errors gracefully" do
+        result = described_class.call
+
+        expect(result[:errors]).to include(a_string_matching(/Network error/))
+        expect(result[:equivalencies_synced]).to eq(0)
+      end
+    end
+
+    context "when TES returns non-200 status" do
+      before do
+        stub_request(:get, /tes\.collegesource\.com/)
+          .to_return(status: 500, body: "Internal Server Error")
+      end
+
+      it "handles HTTP errors gracefully" do
+        result = described_class.call
+
+        expect(result[:errors]).to include(a_string_matching(/error/i))
+      end
+    end
+  end
+
+  describe "#find_wit_course (private)" do
+    let(:service) { described_class.new }
+
+    let!(:comp_course) do
+      create(:course, subject: "Computer Science (COMP)", course_number: 1000)
+    end
+
+    it "finds course by subject abbreviation and number" do
+      result = service.send(:find_wit_course, "COMP 1000")
+      expect(result).to eq(comp_course)
+    end
+
+    it "finds course without space in code" do
+      result = service.send(:find_wit_course, "COMP1000")
+      expect(result).to eq(comp_course)
+    end
+
+    it "returns nil for unknown course" do
+      result = service.send(:find_wit_course, "UNKN 9999")
+      expect(result).to be_nil
+    end
+
+    it "returns nil for blank input" do
+      result = service.send(:find_wit_course, "")
+      expect(result).to be_nil
+    end
+  end
+
+  describe "#generate_university_code (private)" do
+    let(:service) { described_class.new }
+
+    it "generates code from university name" do
+      code = service.send(:generate_university_code, "Boston University")
+      expect(code).to be_present
+      expect(code).to match(/\A[A-Z-]+\z/)
+    end
+
+    it "generates different codes for different universities" do
+      code1 = service.send(:generate_university_code, "Boston University")
+      code2 = service.send(:generate_university_code, "Northeastern University")
+      expect(code1).not_to eq(code2)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Implements `Transfer::EquivalencySyncService` to fetch and parse transfer equivalency data from WIT's TES database (CollegeSource)
- Adds `TransferEquivalencySyncJob` for async sync processing and a rake task (`rake transfer:sync_equivalencies`)
- Creates admin page at `/admin/transfer_equivalencies` with stats dashboard, search/filter, and "Sync Now" button
- Adds Pundit policy and navigation registry entry for transfer equivalencies

## Implementation Details
The TES page is an ASP.NET WebForms application that requires interactive postbacks. The service:
1. Fetches the TES public view page
2. Looks for the `gdvCourseEQ` grid (direct parse)
3. If not found, attempts an ASP.NET postback to trigger the search
4. Parses equivalency rows into university, course, and equivalency records
5. Matches WIT courses by subject abbreviation + course number

## Files Changed
- `app/services/transfer/equivalency_sync_service.rb` - Core sync service
- `app/jobs/transfer_equivalency_sync_job.rb` - Background job
- `app/controllers/admin/transfer_equivalencies_controller.rb` - Admin controller
- `app/views/admin/transfer_equivalencies/index.html.erb` - Admin view
- `app/policies/transfer/equivalency_policy.rb` - Pundit policy
- `app/services/admin/navigation_registry.rb` - Nav entry added
- `config/routes.rb` - Admin routes added
- `lib/tasks/transfer.rake` - Rake task
- `spec/services/transfer/equivalency_sync_service_spec.rb` - Service specs
- `spec/jobs/transfer_equivalency_sync_job_spec.rb` - Job specs

## Test Plan
- [x] RSpec tests for service (stubbed HTTP, grid parsing, error handling)
- [x] RSpec tests for job (service delegation, error handling)
- [x] Rubocop passes with no offenses
- [ ] Note: Test DB has a permissions issue locally (`PG::InsufficientPrivilege`) preventing spec execution -- this is a pre-existing environment issue unrelated to this PR

Closes #342
Part of #335