### PR TITLE
feat: multi-semester planning tool (#341)

### DIFF
--- a/app/controllers/api/course_plans_controller.rb
+++ b/app/controllers/api/course_plans_controller.rb
@@ -11,14 +11,14 @@ module Api
       plans = policy_scope(CoursePlan)
       plans = plans.by_term(Term.find_by!(uid: params[:term_uid])) if params[:term_uid].present?
 
-      render json: plans.includes(:term, :course).map { |plan| serialize_plan(plan) }
+      render json: plans.includes(:term, :course).map { |plan| CoursePlanSerializer.new(plan).as_json }
     end
 
     # GET /api/users/me/course_plans/:id
     def show
       authorize @plan
 
-      render json: serialize_plan(@plan)
+      render json: CoursePlanSerializer.new(@plan).as_json
     end
 
     # POST /api/users/me/course_plans
@@ -42,7 +42,7 @@ module Api
       authorize @plan
 
       @plan.save!
-      render json: serialize_plan(@plan), status: :created
+      render json: CoursePlanSerializer.new(@plan).as_json, status: :created
     end
 
     # PATCH /api/users/me/course_plans/:id
@@ -50,7 +50,7 @@ module Api
       authorize @plan
 
       @plan.update!(plan_update_params)
-      render json: serialize_plan(@plan)
+      render json: CoursePlanSerializer.new(@plan).as_json
     end
 
     # DELETE /api/users/me/course_plans/:id
@@ -75,7 +75,7 @@ module Api
 
       render json: {
         suggestions: suggestions.transform_keys { |term| term.uid.to_s }.transform_values do |courses|
-          courses.map { |c| serialize_suggestion(c) }
+          courses.map { |c| CourseSuggestionSerializer.new(c).as_json }
         end
       }
     end
@@ -103,34 +103,6 @@ module Api
 
     def plan_update_params
       params.permit(:status, :notes, :planned_crn)
-    end
-
-    def serialize_plan(plan)
-      {
-        id: plan.id,
-        term: TermSerializer.new(plan.term).as_json,
-        subject: plan.planned_subject,
-        course_number: plan.planned_course_number,
-        crn: plan.planned_crn,
-        course_identifier: plan.course_identifier,
-        status: plan.status,
-        notes: plan.notes,
-        course_id: plan.course_id,
-        created_at: plan.created_at,
-        updated_at: plan.updated_at
-      }
-    end
-
-    def serialize_suggestion(course)
-      {
-        id: course.id,
-        subject: course.subject,
-        course_number: course.course_number,
-        crn: course.crn,
-        title: course.title,
-        credit_hours: course.credit_hours,
-        schedule_type: course.schedule_type
-      }
     end
 
   end

--- a/app/controllers/api/course_plans_controller.rb
+++ b/app/controllers/api/course_plans_controller.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+module Api
+  class CoursePlansController < ApiController
+    before_action :set_course_plan, only: [:show, :update, :destroy]
+
+    # GET /api/users/me/course_plans
+    def index
+      authorize CoursePlan
+
+      plans = policy_scope(CoursePlan)
+      plans = plans.by_term(Term.find_by!(uid: params[:term_uid])) if params[:term_uid].present?
+
+      render json: plans.includes(:term, :course).map { |plan| serialize_plan(plan) }
+    end
+
+    # GET /api/users/me/course_plans/:id
+    def show
+      authorize @plan
+
+      render json: serialize_plan(@plan)
+    end
+
+    # POST /api/users/me/course_plans
+    def create
+      term = Term.find_by!(uid: params[:term_uid])
+
+      @plan = current_user.course_plans.build(
+        term: term,
+        planned_subject: params[:subject]&.upcase,
+        planned_course_number: params[:course_number],
+        planned_crn: params[:crn],
+        notes: params[:notes],
+        status: params[:status] || :planned
+      )
+
+      # Link to existing Course record if CRN provided
+      if params[:crn].present?
+        @plan.course = Course.find_by(term: term, crn: params[:crn])
+      end
+
+      authorize @plan
+
+      @plan.save!
+      render json: serialize_plan(@plan), status: :created
+    end
+
+    # PATCH /api/users/me/course_plans/:id
+    def update
+      authorize @plan
+
+      @plan.update!(plan_update_params)
+      render json: serialize_plan(@plan)
+    end
+
+    # DELETE /api/users/me/course_plans/:id
+    def destroy
+      authorize @plan
+
+      @plan.destroy!
+      head :no_content
+    end
+
+    # POST /api/users/me/course_plans/generate
+    def generate
+      authorize CoursePlan
+
+      terms = Array(params[:term_uids]).map { |uid| Term.find_by!(uid: uid) }
+      if terms.empty?
+        render json: { error: "term_uids are required" }, status: :bad_request
+        return
+      end
+
+      suggestions = CoursePlannerService.new(current_user).generate_plan(terms: terms)
+
+      render json: {
+        suggestions: suggestions.transform_keys { |term| term.uid.to_s }.transform_values do |courses|
+          courses.map { |c| serialize_suggestion(c) }
+        end
+      }
+    end
+
+    # POST /api/users/me/course_plans/validate
+    def validate
+      authorize CoursePlan
+
+      if params[:term_uid].blank?
+        render json: { error: "term_uid is required" }, status: :bad_request
+        return
+      end
+
+      term = Term.find_by!(uid: params[:term_uid])
+      result = CoursePlannerService.new(current_user).validate_plan(term: term)
+
+      render json: result
+    end
+
+    private
+
+    def set_course_plan
+      @plan = policy_scope(CoursePlan).find(params[:id])
+    end
+
+    def plan_update_params
+      params.permit(:status, :notes, :planned_crn)
+    end
+
+    def serialize_plan(plan)
+      {
+        id: plan.id,
+        term: TermSerializer.new(plan.term).as_json,
+        subject: plan.planned_subject,
+        course_number: plan.planned_course_number,
+        crn: plan.planned_crn,
+        course_identifier: plan.course_identifier,
+        status: plan.status,
+        notes: plan.notes,
+        course_id: plan.course_id,
+        created_at: plan.created_at,
+        updated_at: plan.updated_at
+      }
+    end
+
+    def serialize_suggestion(course)
+      {
+        id: course.id,
+        subject: course.subject,
+        course_number: course.course_number,
+        crn: course.crn,
+        title: course.title,
+        credit_hours: course.credit_hours,
+        schedule_type: course.schedule_type
+      }
+    end
+
+  end
+end

--- a/app/policies/course_plan_policy.rb
+++ b/app/policies/course_plan_policy.rb
@@ -1,12 +1,24 @@
 # frozen_string_literal: true
 
 class CoursePlanPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
   def show?
     owner_of_record? || admin?
   end
 
   def create?
-    true # Any authenticated user can create course plans
+    true
+  end
+
+  def generate?
+    true
+  end
+
+  def validate?
+    true
   end
 
   def update?

--- a/app/serializers/course_plan_serializer.rb
+++ b/app/serializers/course_plan_serializer.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class CoursePlanSerializer
+  def initialize(plan)
+    @plan = plan
+  end
+
+  def as_json(*)
+    {
+      id: @plan.id,
+      term: TermSerializer.new(@plan.term).as_json,
+      subject: @plan.planned_subject,
+      course_number: @plan.planned_course_number,
+      crn: @plan.planned_crn,
+      course_identifier: @plan.course_identifier,
+      status: @plan.status,
+      notes: @plan.notes,
+      course_id: @plan.course_id,
+      created_at: @plan.created_at,
+      updated_at: @plan.updated_at
+    }
+  end
+
+end

--- a/app/serializers/course_suggestion_serializer.rb
+++ b/app/serializers/course_suggestion_serializer.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CourseSuggestionSerializer
+  def initialize(course)
+    @course = course
+  end
+
+  def as_json(*)
+    {
+      id: @course.id,
+      subject: @course.subject,
+      course_number: @course.course_number,
+      crn: @course.crn,
+      title: @course.title,
+      credit_hours: @course.credit_hours,
+      schedule_type: @course.schedule_type
+    }
+  end
+
+end

--- a/app/services/course_planner_service.rb
+++ b/app/services/course_planner_service.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+# Generates multi-semester course plan suggestions and validates existing plans.
+#
+# Usage:
+#   service = CoursePlannerService.new(user)
+#   suggestions = service.generate_plan(terms: [term1, term2])
+#   # => { term1 => [course1, course2], term2 => [course3] }
+#
+#   validation = service.validate_plan(term: term)
+#   # => { valid: true/false, issues: [...], warnings: [...] }
+class CoursePlannerService
+  MAX_CREDITS_PER_TERM = 18
+
+  def initialize(user)
+    @user = user
+  end
+
+  # Generate course suggestions for the given terms.
+  # Returns a hash of { Term => [Course, ...] } without auto-saving.
+  def generate_plan(terms:)
+    unfulfilled = unfulfilled_requirements
+    fulfilled_codes = completed_course_codes.dup
+    planned_courses_by_term = {}
+
+    terms.sort_by(&:start_date).each do |term|
+      planned_credits = existing_credits_for_term(term)
+      term_courses = []
+
+      available_courses = Course.where(term: term, status: :active)
+                                .where.not(credit_hours: nil)
+                                .includes(:course_prerequisites, :meeting_times)
+
+      unfulfilled.each do |req|
+        break if planned_credits >= MAX_CREDITS_PER_TERM
+
+        matching = find_matching_courses(available_courses, req, fulfilled_codes)
+
+        matching.each do |course|
+          break if planned_credits + (course.credit_hours || 0) > MAX_CREDITS_PER_TERM
+          next if term_courses.any? { |c| c.id == course.id }
+          next if schedule_conflict?(course, term_courses)
+          next unless prerequisites_met?(course, fulfilled_codes)
+
+          term_courses << course
+          planned_credits += course.credit_hours || 0
+          fulfilled_codes << "#{course.subject}#{course.course_number}"
+          break # One course per requirement, move to next
+        end
+      end
+
+      planned_courses_by_term[term] = term_courses
+    end
+
+    planned_courses_by_term
+  end
+
+  # Validate a user's existing course plan for a term.
+  # Returns { valid:, issues:, warnings: }
+  def validate_plan(term:)
+    plans = @user.course_plans.active.by_term(term).includes(course: [:course_prerequisites, :meeting_times])
+    issues = []
+    warnings = []
+
+    # Check credit hours
+    total_credits = plans.joins(:course).sum("courses.credit_hours")
+    if total_credits > MAX_CREDITS_PER_TERM
+      issues << "Total credits (#{total_credits}) exceed maximum of #{MAX_CREDITS_PER_TERM}"
+    elsif total_credits > 15
+      warnings << "Heavy course load: #{total_credits} credits"
+    end
+
+    # Check prerequisites for each planned course
+    plans.each do |plan|
+      next unless plan.course
+
+      result = PrerequisiteValidationService.call(user: @user, course: plan.course)
+      unless result[:eligible]
+        unmet = result[:requirements].reject { |r| r[:met] }.map { |r| r[:rule] }
+        issues << "Prerequisites not met for #{plan.course_identifier}: #{unmet.join(', ')}"
+      end
+    end
+
+    # Check schedule conflicts
+    courses_with_meetings = plans.select(&:course).map(&:course).select { |c| c.meeting_times.any? }
+    conflicts = find_schedule_conflicts(courses_with_meetings)
+    conflicts.each do |conflict|
+      issues << "Schedule conflict: #{conflict[:course_a]} and #{conflict[:course_b]} overlap on #{conflict[:day]}"
+    end
+
+    # Check requirement fulfillment
+    linked_plans = plans.select(&:course)
+    if linked_plans.empty? && plans.any?
+      warnings << "No plans are linked to actual course sections yet"
+    end
+
+    {
+      valid: issues.empty?,
+      issues: issues,
+      warnings: warnings,
+      summary: {
+        total_credits: total_credits,
+        course_count: plans.size
+      }
+    }
+  end
+
+  private
+
+  def completed_course_codes
+    @completed_course_codes ||= @user.requirement_completions
+                                     .where(in_progress: false)
+                                     .pluck(:subject, :course_number)
+                                     .map { |subject, number| "#{subject}#{number}" }
+  end
+
+  def unfulfilled_requirements
+    user_programs = UserDegreeProgram.where(user: @user, status: :active)
+    return [] if user_programs.empty?
+
+    program_ids = user_programs.pluck(:degree_program_id)
+    all_requirements = DegreeRequirement.where(degree_program_id: program_ids)
+                                        .where.not(subject: nil)
+                                        .where.not(course_number: nil)
+
+    completed = completed_course_codes.to_set
+
+    all_requirements.reject { |req| completed.include?("#{req.subject}#{req.course_number}") }
+  end
+
+  def existing_credits_for_term(term)
+    CoursePlan.total_credits_for_term(@user, term)
+  end
+
+  def find_matching_courses(available_courses, requirement, fulfilled_codes)
+    return [] unless requirement.subject && requirement.course_number
+
+    available_courses.select do |course|
+      course.subject&.include?(requirement.subject) &&
+        course.course_number == requirement.course_number &&
+        fulfilled_codes.exclude?("#{course.subject}#{course.course_number}")
+    end
+  end
+
+  def prerequisites_met?(course, fulfilled_codes)
+    return true if course.course_prerequisites.empty?
+
+    # Simple check: see if all prerequisite course codes are in fulfilled list
+    result = PrerequisiteValidationService.call(user: @user, course: course)
+    result[:eligible]
+  end
+
+  def schedule_conflict?(new_course, existing_courses)
+    new_meetings = new_course.meeting_times
+    return false if new_meetings.empty?
+
+    existing_courses.any? do |existing|
+      existing.meeting_times.any? do |existing_mt|
+        new_meetings.any? do |new_mt|
+          times_overlap?(existing_mt, new_mt)
+        end
+      end
+    end
+  end
+
+  def find_schedule_conflicts(courses)
+    conflicts = []
+
+    courses.combination(2).each do |course_a, course_b|
+      course_a.meeting_times.each do |mt_a|
+        course_b.meeting_times.each do |mt_b|
+          next unless times_overlap?(mt_a, mt_b)
+
+          conflicts << {
+            course_a: "#{course_a.subject} #{course_a.course_number}",
+            course_b: "#{course_b.subject} #{course_b.course_number}",
+            day: mt_a.day_of_week
+          }
+        end
+      end
+    end
+
+    conflicts.uniq { |c| [c[:course_a], c[:course_b], c[:day]] }
+  end
+
+  def times_overlap?(mt_a, mt_b)
+    return false if mt_a.day_of_week != mt_b.day_of_week
+
+    mt_a.begin_time < mt_b.end_time && mt_b.begin_time < mt_a.end_time
+  end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -432,6 +432,16 @@ Rails.application.routes.draw do
     get "users/me/crn_list", to: "crn_list#index"
     post "users/me/crn_list/courses", to: "crn_list#add_course"
     delete "users/me/crn_list/courses/:id", to: "crn_list#remove_course"
+
+    # Course Plans (multi-semester planning)
+    scope "users/me" do
+      resources :course_plans, only: [:index, :show, :create, :update, :destroy] do
+        collection do
+          post :generate
+          post :validate
+        end
+      end
+    end
   end
 
   get "/calendar/:calendar_token", to: "calendars#show", as: :calendar, defaults: { format: :ics }

--- a/spec/requests/api/course_plans_spec.rb
+++ b/spec/requests/api/course_plans_spec.rb
@@ -1,0 +1,286 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::CoursePlans" do
+  let(:user) { create(:user) }
+  let(:jwt_token) { JsonWebTokenService.encode(user_id: user.id) }
+  let(:headers) { { "Authorization" => "Bearer #{jwt_token}", "Content-Type" => "application/json" } }
+
+  before { Flipper.enable(FlipperFlags::V1, user) }
+
+  describe "GET /api/users/me/course_plans" do
+    let(:term) { create(:term) }
+
+    it "requires authentication" do
+      get "/api/users/me/course_plans"
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns empty array when no plans exist" do
+      get "/api/users/me/course_plans", headers: headers
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq([])
+    end
+
+    context "with plans" do
+      let!(:plan) { create(:course_plan, user: user, term: term) }
+
+      it "returns all user plans" do
+        get "/api/users/me/course_plans", headers: headers
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json.size).to eq(1)
+        expect(json.first["id"]).to eq(plan.id)
+        expect(json.first["subject"]).to eq(plan.planned_subject)
+      end
+
+      it "filters by term_uid" do
+        other_term = create(:term)
+        create(:course_plan, user: user, term: other_term, planned_course_number: 9999)
+
+        get "/api/users/me/course_plans?term_uid=#{term.uid}", headers: headers
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json.size).to eq(1)
+        expect(json.first["id"]).to eq(plan.id)
+      end
+
+      it "does not return other users plans" do
+        other_user = create(:user)
+        create(:course_plan, user: other_user, term: term)
+
+        get "/api/users/me/course_plans", headers: headers
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json.size).to eq(1)
+      end
+    end
+  end
+
+  describe "GET /api/users/me/course_plans/:id" do
+    let(:term) { create(:term) }
+    let!(:plan) { create(:course_plan, user: user, term: term) }
+
+    it "requires authentication" do
+      get "/api/users/me/course_plans/#{plan.id}"
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns the plan" do
+      get "/api/users/me/course_plans/#{plan.id}", headers: headers
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json["id"]).to eq(plan.id)
+      expect(json["subject"]).to eq(plan.planned_subject)
+      expect(json["status"]).to eq("planned")
+    end
+
+    it "returns 404 for another users plan" do
+      other_user = create(:user)
+      other_plan = create(:course_plan, user: other_user, term: term)
+
+      get "/api/users/me/course_plans/#{other_plan.id}", headers: headers
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "POST /api/users/me/course_plans" do
+    let(:term) { create(:term) }
+
+    it "requires authentication" do
+      post "/api/users/me/course_plans",
+           params: { term_uid: term.uid, subject: "COMP", course_number: 1000 }.to_json,
+           headers: { "Content-Type" => "application/json" }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "creates a course plan" do
+      post "/api/users/me/course_plans",
+           params: { term_uid: term.uid, subject: "COMP", course_number: 2000, notes: "Need this class" }.to_json,
+           headers: headers
+
+      expect(response).to have_http_status(:created)
+      json = response.parsed_body
+      expect(json["subject"]).to eq("COMP")
+      expect(json["course_number"]).to eq(2000)
+      expect(json["notes"]).to eq("Need this class")
+      expect(json["status"]).to eq("planned")
+      expect(user.course_plans.count).to eq(1)
+    end
+
+    it "links to a course when CRN is provided" do
+      course = create(:course, term: term, crn: 77777)
+      post "/api/users/me/course_plans",
+           params: { term_uid: term.uid, subject: course.subject, course_number: course.course_number, crn: 77777 }.to_json,
+           headers: headers
+
+      expect(response).to have_http_status(:created)
+      plan = user.course_plans.last
+      expect(plan.course).to eq(course)
+    end
+
+    it "returns 404 for unknown term" do
+      post "/api/users/me/course_plans",
+           params: { term_uid: "INVALID", subject: "COMP", course_number: 1000 }.to_json,
+           headers: headers
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns error for missing required fields" do
+      post "/api/users/me/course_plans",
+           params: { term_uid: term.uid, subject: "COMP" }.to_json,
+           headers: headers
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+  end
+
+  describe "PATCH /api/users/me/course_plans/:id" do
+    let(:term) { create(:term) }
+    let!(:plan) { create(:course_plan, user: user, term: term) }
+
+    it "requires authentication" do
+      patch "/api/users/me/course_plans/#{plan.id}",
+            params: { status: "enrolled" }.to_json,
+            headers: { "Content-Type" => "application/json" }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "updates the plan status" do
+      patch "/api/users/me/course_plans/#{plan.id}",
+            params: { status: "enrolled" }.to_json,
+            headers: headers
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json["status"]).to eq("enrolled")
+      expect(plan.reload.status).to eq("enrolled")
+    end
+
+    it "updates notes" do
+      patch "/api/users/me/course_plans/#{plan.id}",
+            params: { notes: "Updated notes" }.to_json,
+            headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(plan.reload.notes).to eq("Updated notes")
+    end
+
+    it "cannot update another users plan" do
+      other_user = create(:user)
+      other_plan = create(:course_plan, user: other_user, term: term)
+
+      patch "/api/users/me/course_plans/#{other_plan.id}",
+            params: { status: "enrolled" }.to_json,
+            headers: headers
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "DELETE /api/users/me/course_plans/:id" do
+    let(:term) { create(:term) }
+    let!(:plan) { create(:course_plan, user: user, term: term) }
+
+    it "requires authentication" do
+      delete "/api/users/me/course_plans/#{plan.id}"
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "deletes the plan" do
+      delete "/api/users/me/course_plans/#{plan.id}", headers: headers
+      expect(response).to have_http_status(:no_content)
+      expect(user.course_plans.count).to eq(0)
+    end
+
+    it "cannot delete another users plan" do
+      other_user = create(:user)
+      other_plan = create(:course_plan, user: other_user, term: term)
+
+      delete "/api/users/me/course_plans/#{other_plan.id}", headers: headers
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "POST /api/users/me/course_plans/generate" do
+    let(:term) { create(:term, :future, uid: 202730, year: 2027, season: :fall, start_date: 6.months.from_now.to_date, end_date: 10.months.from_now.to_date) }
+
+    it "requires authentication" do
+      post "/api/users/me/course_plans/generate",
+           params: { term_uids: [term.uid] }.to_json,
+           headers: { "Content-Type" => "application/json" }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns suggestions grouped by term" do
+      degree_program = create(:degree_program)
+      create(:user_degree_program, user: user, degree_program: degree_program)
+      create(:degree_requirement, :specific_course, degree_program: degree_program, subject: "COMP", course_number: 3000)
+      create(:course, term: term, subject: "COMP", course_number: 3000, credit_hours: 3, crn: 80001)
+
+      post "/api/users/me/course_plans/generate",
+           params: { term_uids: [term.uid] }.to_json,
+           headers: headers
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json).to have_key("suggestions")
+      expect(json["suggestions"]).to have_key(term.uid.to_s)
+    end
+
+    it "returns bad request without term_uids" do
+      post "/api/users/me/course_plans/generate",
+           params: {}.to_json,
+           headers: headers
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "returns 404 for invalid term uid" do
+      post "/api/users/me/course_plans/generate",
+           params: { term_uids: [999999] }.to_json,
+           headers: headers
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "POST /api/users/me/course_plans/validate" do
+    let(:term) { create(:term, :current) }
+
+    it "requires authentication" do
+      post "/api/users/me/course_plans/validate",
+           params: { term_uid: term.uid }.to_json,
+           headers: { "Content-Type" => "application/json" }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "validates a plan" do
+      course = create(:course, term: term, credit_hours: 3)
+      create(:course_plan, user: user, term: term, course: course,
+             planned_subject: course.subject, planned_course_number: course.course_number)
+
+      post "/api/users/me/course_plans/validate",
+           params: { term_uid: term.uid }.to_json,
+           headers: headers
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json).to have_key("valid")
+      expect(json).to have_key("issues")
+      expect(json).to have_key("warnings")
+      expect(json).to have_key("summary")
+    end
+
+    it "returns bad request without term_uid" do
+      post "/api/users/me/course_plans/validate",
+           params: {}.to_json,
+           headers: headers
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "returns 404 for invalid term uid" do
+      post "/api/users/me/course_plans/validate",
+           params: { term_uid: 999999 }.to_json,
+           headers: headers
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/services/course_planner_service_spec.rb
+++ b/spec/services/course_planner_service_spec.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CoursePlannerService do
+  let(:user) { create(:user) }
+  let(:service) { described_class.new(user) }
+
+  describe "#generate_plan" do
+    let(:term) { create(:term, :future, uid: 202630, year: 2026, season: :fall, start_date: 6.months.from_now.to_date, end_date: 10.months.from_now.to_date) }
+    let(:degree_program) { create(:degree_program) }
+
+    before do
+      create(:user_degree_program, user: user, degree_program: degree_program)
+    end
+
+    context "with unfulfilled requirements and matching courses" do
+      let!(:requirement) do
+        create(:degree_requirement, :specific_course, degree_program: degree_program, subject: "COMP", course_number: 2000)
+      end
+      let!(:course) do
+        create(:course, term: term, subject: "COMP", course_number: 2000, credit_hours: 3)
+      end
+
+      it "suggests courses that fulfill requirements" do
+        result = service.generate_plan(terms: [term])
+
+        expect(result[term]).to include(course)
+      end
+    end
+
+    context "when all requirements are already completed" do
+      let!(:requirement) do
+        create(:degree_requirement, :specific_course, degree_program: degree_program, subject: "COMP", course_number: 1000)
+      end
+
+      before do
+        create(:requirement_completion, user: user, degree_requirement: requirement, subject: "COMP", course_number: 1000)
+      end
+
+      it "returns empty suggestions" do
+        result = service.generate_plan(terms: [term])
+
+        expect(result[term]).to be_empty
+      end
+    end
+
+    context "with credit hour limits" do
+      before do
+        # Create 7 requirements, each needing a 3-credit course = 21 credits
+        7.times do |i|
+          req = create(:degree_requirement, :specific_course, degree_program: degree_program, subject: "COMP", course_number: 1000 + i)
+          create(:course, term: term, subject: "COMP", course_number: 1000 + i, credit_hours: 3, crn: 20000 + i)
+        end
+      end
+
+      it "does not exceed 18 credit hours per term" do
+        result = service.generate_plan(terms: [term])
+
+        total = result[term].sum(&:credit_hours)
+        expect(total).to be <= 18
+      end
+    end
+
+    context "with multiple terms" do
+      let(:term2) { create(:term, :future, uid: 202710, year: 2027, season: :spring, start_date: 12.months.from_now.to_date, end_date: 16.months.from_now.to_date) }
+      let!(:req1) { create(:degree_requirement, :specific_course, degree_program: degree_program, subject: "COMP", course_number: 1000) }
+      let!(:req2) { create(:degree_requirement, :specific_course, degree_program: degree_program, subject: "COMP", course_number: 2000) }
+      let!(:course1) { create(:course, term: term, subject: "COMP", course_number: 1000, credit_hours: 3, crn: 30001) }
+      let!(:course2) { create(:course, term: term2, subject: "COMP", course_number: 2000, credit_hours: 3, crn: 30002) }
+
+      it "distributes courses across terms" do
+        result = service.generate_plan(terms: [term, term2])
+
+        expect(result[term]).to include(course1)
+        expect(result[term2]).to include(course2)
+      end
+    end
+
+    context "with no degree program" do
+      before { UserDegreeProgram.where(user: user).destroy_all }
+
+      it "returns empty suggestions" do
+        result = service.generate_plan(terms: [term])
+
+        expect(result[term]).to be_empty
+      end
+    end
+
+    context "with schedule conflicts" do
+      let(:room) { create(:room) }
+      let!(:requirement1) { create(:degree_requirement, :specific_course, degree_program: degree_program, subject: "COMP", course_number: 1000) }
+      let!(:requirement2) { create(:degree_requirement, :specific_course, degree_program: degree_program, subject: "MATH", course_number: 2000) }
+      let!(:course1) { create(:course, term: term, subject: "COMP", course_number: 1000, credit_hours: 3, crn: 40001) }
+      let!(:course2) { create(:course, term: term, subject: "MATH", course_number: 2000, credit_hours: 3, crn: 40002) }
+
+      before do
+        create(:meeting_time, course: course1, room: room, day_of_week: :monday, begin_time: 1000, end_time: 1150)
+        create(:meeting_time, course: course2, room: room, day_of_week: :monday, begin_time: 1100, end_time: 1250)
+      end
+
+      it "avoids scheduling conflicting courses" do
+        result = service.generate_plan(terms: [term])
+
+        # Should only pick one of the two conflicting courses
+        expect(result[term].size).to eq(1)
+      end
+    end
+  end
+
+  describe "#validate_plan" do
+    let(:term) { create(:term, :current) }
+
+    context "with a valid plan" do
+      let(:course) { create(:course, term: term, credit_hours: 3) }
+
+      before do
+        create(:course_plan, user: user, term: term, course: course,
+               planned_subject: course.subject, planned_course_number: course.course_number)
+      end
+
+      it "returns valid with no issues" do
+        result = service.validate_plan(term: term)
+
+        expect(result[:valid]).to be true
+        expect(result[:issues]).to be_empty
+      end
+
+      it "includes summary with credit count" do
+        result = service.validate_plan(term: term)
+
+        expect(result[:summary][:total_credits]).to eq(3)
+        expect(result[:summary][:course_count]).to eq(1)
+      end
+    end
+
+    context "with excessive credits" do
+      before do
+        7.times do |i|
+          course = create(:course, term: term, credit_hours: 3, crn: 50000 + i,
+                         subject: "SUBJ#{i}", course_number: 1000 + i)
+          create(:course_plan, user: user, term: term, course: course,
+                 planned_subject: course.subject, planned_course_number: course.course_number)
+        end
+      end
+
+      it "reports credit hour issue" do
+        result = service.validate_plan(term: term)
+
+        expect(result[:valid]).to be false
+        expect(result[:issues]).to include(match(/exceed maximum/))
+      end
+    end
+
+    context "with schedule conflicts" do
+      let(:room) { create(:room) }
+      let(:course1) { create(:course, term: term, credit_hours: 3, crn: 60001, subject: "COMP", course_number: 1000) }
+      let(:course2) { create(:course, term: term, credit_hours: 3, crn: 60002, subject: "MATH", course_number: 2000) }
+
+      before do
+        create(:meeting_time, course: course1, room: room, day_of_week: :monday, begin_time: 1000, end_time: 1150)
+        create(:meeting_time, course: course2, room: room, day_of_week: :monday, begin_time: 1100, end_time: 1250)
+        create(:course_plan, user: user, term: term, course: course1,
+               planned_subject: course1.subject, planned_course_number: course1.course_number)
+        create(:course_plan, user: user, term: term, course: course2,
+               planned_subject: course2.subject, planned_course_number: course2.course_number)
+      end
+
+      it "detects schedule conflicts" do
+        result = service.validate_plan(term: term)
+
+        expect(result[:valid]).to be false
+        expect(result[:issues]).to include(match(/Schedule conflict/))
+      end
+    end
+
+    context "with unmet prerequisites" do
+      let(:course) { create(:course, term: term, credit_hours: 3) }
+
+      before do
+        create(:course_prerequisite, course: course, prerequisite_rule: "COMP1000", prerequisite_type: "prerequisite")
+        create(:course_plan, user: user, term: term, course: course,
+               planned_subject: course.subject, planned_course_number: course.course_number)
+      end
+
+      it "reports prerequisite issues" do
+        result = service.validate_plan(term: term)
+
+        expect(result[:valid]).to be false
+        expect(result[:issues]).to include(match(/Prerequisites not met/))
+      end
+    end
+
+    context "with no plans" do
+      it "returns valid with empty plan" do
+        result = service.validate_plan(term: term)
+
+        expect(result[:valid]).to be true
+        expect(result[:issues]).to be_empty
+        expect(result[:summary][:course_count]).to eq(0)
+      end
+    end
+
+    context "with plans not linked to courses" do
+      before do
+        create(:course_plan, user: user, term: term, course: nil,
+               planned_subject: "COMP", planned_course_number: 1000)
+      end
+
+      it "warns about unlinked plans" do
+        result = service.validate_plan(term: term)
+
+        expect(result[:warnings]).to include(match(/linked to actual course sections/))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Implements `CoursePlannerService` for generating multi-semester course plan suggestions based on unfulfilled degree requirements, prerequisite eligibility, schedule conflict detection, and credit hour limits
- Full CRUD API for `CoursePlan` at `/api/users/me/course_plans` (index, show, create, update, destroy)
- `POST /generate` endpoint returns suggested courses grouped by term (does not auto-save)
- `POST /validate` endpoint checks prerequisites, schedule conflicts, and credit limits for a term's plan
- Updates `CoursePlanPolicy` with `index?`, `generate?`, and `validate?` methods
- 41 passing specs covering service and controller

## Test plan
- [x] `bundle exec rspec spec/services/course_planner_service_spec.rb` (all passing)
- [x] `bundle exec rspec spec/requests/api/course_plans_spec.rb` (all passing)
- [x] `bundle exec rubocop` (no offenses on new files)
- [ ] Manual testing of CRUD endpoints with JWT auth
- [ ] Verify generate endpoint returns sensible suggestions with real degree data
- [ ] Verify validate endpoint catches prerequisite/conflict/credit issues

Closes #341
Part of #335

PR assisted by Claude