### PR TITLE
feat: course recommendations engine (#340)

### DIFF
--- a/app/controllers/api/course_recommendations_controller.rb
+++ b/app/controllers/api/course_recommendations_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Api
+  class CourseRecommendationsController < ApiController
+    # GET /api/users/me/course_recommendations?term_uid=202430
+    def index
+      authorize current_user, :show?
+
+      term_uid = params[:term_uid]
+      if term_uid.blank?
+        render json: { error: "term_uid is required" }, status: :bad_request
+        return
+      end
+
+      term = Term.find_by(uid: term_uid)
+      if term.nil?
+        render json: { error: "Term not found" }, status: :not_found
+        return
+      end
+
+      result = CourseRecommendationService.call(user: current_user, term: term)
+      render json: result, status: :ok
+    end
+
+  end
+end

--- a/app/services/course_recommendation_service.rb
+++ b/app/services/course_recommendation_service.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+# Recommends courses for a user in a given term based on:
+# - Unfulfilled degree requirements
+# - Prerequisite eligibility
+# - Courses not already planned or completed
+#
+# Usage:
+#   result = CourseRecommendationService.call(user: user, term: term)
+#   result[:recommendations] # => array of recommendation hashes
+class CourseRecommendationService < ApplicationService
+  def initialize(user:, term:)
+    @user = user
+    @term = term
+    super()
+  end
+
+  def call
+    available = available_courses
+    available = exclude_already_planned(available)
+    available = exclude_already_completed(available)
+
+    recommendations = build_recommendations(available)
+    recommendations = rank_recommendations(recommendations)
+
+    {
+      term: { uid: @term.uid, name: @term.name },
+      recommendations: recommendations,
+      total: recommendations.size
+    }
+  end
+
+  private
+
+  # All active courses offered in this term
+  def available_courses
+    Course.where(term: @term, status: :active)
+          .includes(:faculties, :meeting_times, :course_prerequisites)
+  end
+
+  # Exclude courses already in the user's plan for this term
+  def exclude_already_planned(courses)
+    planned_course_ids = @user.course_plans
+                              .where(term: @term)
+                              .where(status: %w[planned enrolled])
+                              .where.not(course_id: nil)
+                              .pluck(:course_id)
+
+    courses.where.not(id: planned_course_ids)
+  end
+
+  # Exclude courses the user has already completed with a passing grade
+  def exclude_already_completed(courses)
+    completed_pairs = completed_course_pairs
+    return courses if completed_pairs.empty?
+
+    # Build SQL conditions to exclude completed subject/course_number combos
+    exclusion_conditions = completed_pairs.map do |subject, course_number|
+      "(courses.subject = #{ActiveRecord::Base.connection.quote(subject)} AND courses.course_number = #{ActiveRecord::Base.connection.quote(course_number)})"
+    end
+
+    courses.where.not(exclusion_conditions.join(" OR "))
+  end
+
+  # Subject/course_number pairs the user has completed (from RequirementCompletion)
+  def completed_course_pairs
+    @completed_course_pairs ||= @user.requirement_completions
+                                     .where(in_progress: false, met_requirement: true)
+                                     .pluck(:subject, :course_number)
+                                     .uniq
+  end
+
+  # Build recommendation entries with metadata
+  def build_recommendations(courses)
+    courses.filter_map do |course|
+      prereq_result = PrerequisiteValidationService.call(user: @user, course: course)
+
+      requirement_match = find_matching_requirement(course)
+      priority = requirement_match ? "required" : "elective"
+
+      {
+        course: serialize_course(course),
+        priority: priority,
+        fulfills_requirement: requirement_match&.area_name,
+        prerequisite_status: prereq_result[:eligible] ? "met" : "not_met",
+        schedule_conflicts: has_schedule_conflicts?(course)
+      }
+    end
+  end
+
+  # Find an unfulfilled degree requirement that this course satisfies
+  def find_matching_requirement(course)
+    unfulfilled_requirements.find do |req|
+      req.specific_course? &&
+        req.subject == course.subject &&
+        req.course_number == course.course_number
+    end
+  end
+
+  # Degree requirements the user hasn't fulfilled yet
+  def unfulfilled_requirements
+    @unfulfilled_requirements ||= load_unfulfilled_requirements
+  end
+
+  def load_unfulfilled_requirements
+    program_ids = UserDegreeProgram.where(user: @user, status: :active).pluck(:degree_program_id)
+    return [] if program_ids.empty?
+
+    all_requirements = DegreeRequirement.where(degree_program_id: program_ids)
+                                        .where.not(subject: nil)
+                                        .where.not(course_number: nil)
+
+    # Filter out requirements already met
+    met_requirement_ids = @user.requirement_completions
+                               .where(met_requirement: true)
+                               .pluck(:degree_requirement_id)
+                               .to_set
+
+    all_requirements.reject { |req| met_requirement_ids.include?(req.id) }
+  end
+
+  # Check if the course conflicts with the user's already-planned courses
+  def has_schedule_conflicts?(course)
+    planned_times = planned_meeting_times
+    return false if planned_times.empty?
+
+    course.meeting_times.any? do |mt|
+      planned_times.any? do |pt|
+        pt[:day] == mt.day_of_week &&
+          times_overlap?(pt[:begin_time], pt[:end_time], mt.begin_time, mt.end_time)
+      end
+    end
+  end
+
+  # Meeting times from the user's already-planned courses in this term
+  def planned_meeting_times
+    @planned_meeting_times ||= begin
+      planned_course_ids = @user.course_plans
+                                .where(term: @term)
+                                .where(status: %w[planned enrolled])
+                                .where.not(course_id: nil)
+                                .pluck(:course_id)
+
+      MeetingTime.where(course_id: planned_course_ids).map do |mt|
+        { day: mt.day_of_week, begin_time: mt.begin_time, end_time: mt.end_time }
+      end
+    end
+  end
+
+  def times_overlap?(start1, end1, start2, end2)
+    return false if start1.nil? || end1.nil? || start2.nil? || end2.nil?
+
+    start1 < end2 && start2 < end1
+  end
+
+  # Rank: required first, then electives. Within each: no conflicts first, then by RMP rating.
+  def rank_recommendations(recommendations)
+    recommendations.sort_by do |rec|
+      priority_order = rec[:priority] == "required" ? 0 : 1
+      conflict_order = rec[:schedule_conflicts] ? 1 : 0
+      rmp_rating = avg_rating_for_course(rec[:course][:id]) || 0
+
+      [priority_order, conflict_order, -rmp_rating]
+    end
+  end
+
+  # Get average RMP rating for the first faculty teaching this course
+  def avg_rating_for_course(course_id)
+    @rating_cache ||= {}
+    return @rating_cache[course_id] if @rating_cache.key?(course_id)
+
+    course = Course.find_by(id: course_id)
+    return @rating_cache[course_id] = nil unless course
+
+    faculty = course.faculties.first
+    return @rating_cache[course_id] = nil unless faculty
+
+    @rating_cache[course_id] = faculty.rating_distribution&.avg_rating&.to_f
+  end
+
+  def serialize_course(course)
+    faculty = course.faculties.first
+
+    {
+      id: course.id,
+      subject: course.subject,
+      course_number: course.course_number,
+      title: course.title,
+      crn: course.crn,
+      credits: course.credit_hours,
+      schedule_type: course.schedule_type,
+      faculty: if faculty
+                 {
+                   name: faculty.full_name,
+                   rmp_rating: faculty.rating_distribution&.avg_rating&.to_f
+                 }
+               end
+    }
+  end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,9 @@
 #                api_terms_current_and_next GET    /api/terms/current_and_next(.:format)                                                             api/misc#get_current_terms
 #                       api_process_courses POST   /api/process_courses(.:format)                                                                    api/courses#process_courses
 #                     api_courses_reprocess POST   /api/courses/reprocess(.:format)                                                                  api/courses#reprocess
+#                  prerequisites_api_course GET    /api/courses/:id/prerequisites(.:format)                                                          api/courses#prerequisites
+#              check_eligibility_api_course POST   /api/courses/:id/check_eligibility(.:format)                                                      api/courses#check_eligibility
+#                                api_course GET    /api/courses/:id(.:format)                                                                        api/courses#show
 #          preview_api_calendar_preferences POST   /api/calendar_preferences/preview(.:format)                                                       api/calendar_preferences#preview
 #                  api_calendar_preferences GET    /api/calendar_preferences(.:format)                                                               api/calendar_preferences#index
 #                   api_calendar_preference GET    /api/calendar_preferences/:id(.:format)                                                           api/calendar_preferences#show
@@ -70,6 +73,7 @@
 #                     api_users_me_crn_list GET    /api/users/me/crn_list(.:format)                                                                  api/crn_list#index
 #             api_users_me_crn_list_courses POST   /api/users/me/crn_list/courses(.:format)                                                          api/crn_list#add_course
 #                                           DELETE /api/users/me/crn_list/courses/:id(.:format)                                                      api/crn_list#remove_course
+#       api_users_me_course_recommendations GET    /api/users/me/course_recommendations(.:format)                                                    api/course_recommendations#index
 #                                  calendar GET    /calendar/:calendar_token(.:format)                                                               calendars#show {format: :ics}
 #                               risc_events POST   /risc/events(.:format)                                                                            risc#create
 #               auth_google_oauth2_callback GET    /auth/google_oauth2/callback(.:format)                                                            auth#google
@@ -432,6 +436,9 @@ Rails.application.routes.draw do
     get "users/me/crn_list", to: "crn_list#index"
     post "users/me/crn_list/courses", to: "crn_list#add_course"
     delete "users/me/crn_list/courses/:id", to: "crn_list#remove_course"
+
+    # Course Recommendations
+    get "users/me/course_recommendations", to: "course_recommendations#index"
   end
 
   get "/calendar/:calendar_token", to: "calendars#show", as: :calendar, defaults: { format: :ics }

--- a/spec/requests/api/course_recommendations_spec.rb
+++ b/spec/requests/api/course_recommendations_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Api::CourseRecommendations" do
+  let(:user) { create(:user) }
+  let(:jwt_token) { JsonWebTokenService.encode(user_id: user.id) }
+  let(:headers) { { "Authorization" => "Bearer #{jwt_token}", "Content-Type" => "application/json" } }
+
+  before { Flipper.enable(FlipperFlags::V1, user) }
+
+  describe "GET /api/users/me/course_recommendations" do
+    let(:term) { create(:term) }
+
+    it "requires authentication" do
+      get "/api/users/me/course_recommendations?term_uid=#{term.uid}"
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "requires term_uid" do
+      get "/api/users/me/course_recommendations", headers: headers
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "returns 404 for unknown term" do
+      get "/api/users/me/course_recommendations?term_uid=INVALID", headers: headers
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns recommendations for valid term" do
+      get "/api/users/me/course_recommendations?term_uid=#{term.uid}", headers: headers
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json).to have_key("term")
+      expect(json).to have_key("recommendations")
+      expect(json).to have_key("total")
+    end
+
+    it "returns empty recommendations when no courses exist" do
+      get "/api/users/me/course_recommendations?term_uid=#{term.uid}", headers: headers
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json["recommendations"]).to be_empty
+      expect(json["total"]).to eq(0)
+    end
+
+    context "with courses in the term" do
+      let!(:course) { create(:course, term: term, crn: 55555, credit_hours: 3, subject: "COMP", course_number: 2000) }
+
+      it "returns course recommendations" do
+        get "/api/users/me/course_recommendations?term_uid=#{term.uid}", headers: headers
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json["total"]).to eq(1)
+
+        rec = json["recommendations"].first
+        expect(rec["course"]["crn"]).to eq(55555)
+        expect(rec["course"]["subject"]).to eq("COMP")
+        expect(rec["course"]["course_number"]).to eq(2000)
+        expect(rec["course"]["credits"]).to eq(3)
+        expect(rec).to have_key("priority")
+        expect(rec).to have_key("prerequisite_status")
+        expect(rec).to have_key("schedule_conflicts")
+      end
+    end
+
+    context "excluding planned courses" do
+      let!(:planned_course) { create(:course, term: term, subject: "COMP", course_number: 1000, crn: 11111) }
+      let!(:available_course) { create(:course, term: term, subject: "COMP", course_number: 2000, crn: 22222) }
+
+      before do
+        create(:course_plan, user: user, term: term, course: planned_course,
+                             planned_subject: "COMP", planned_course_number: 1000,
+                             planned_crn: 11111, status: "planned")
+      end
+
+      it "does not recommend already-planned courses" do
+        get "/api/users/me/course_recommendations?term_uid=#{term.uid}", headers: headers
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        crns = json["recommendations"].map { |r| r["course"]["crn"] }
+        expect(crns).not_to include(11111)
+        expect(crns).to include(22222)
+      end
+    end
+  end
+end

--- a/spec/services/course_recommendation_service_spec.rb
+++ b/spec/services/course_recommendation_service_spec.rb
@@ -1,0 +1,250 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CourseRecommendationService do
+  let(:user) { create(:user) }
+  let(:term) { create(:term, uid: 202430, year: 2024, season: :fall) }
+  let(:degree_program) { create(:degree_program) }
+
+  before do
+    create(:user_degree_program, user: user, degree_program: degree_program, primary: true)
+  end
+
+  describe ".call" do
+    it "returns the term info and recommendations array" do
+      result = described_class.call(user: user, term: term)
+
+      expect(result).to have_key(:term)
+      expect(result[:term][:uid]).to eq(202430)
+      expect(result[:term][:name]).to eq("Fall 2024")
+      expect(result).to have_key(:recommendations)
+      expect(result).to have_key(:total)
+    end
+
+    context "with available courses" do
+      let!(:course) do
+        create(:course, term: term, subject: "COMP", course_number: 2000,
+                        title: "Data Structures", crn: 12345, credit_hours: 3)
+      end
+
+      it "includes courses from the given term" do
+        result = described_class.call(user: user, term: term)
+
+        expect(result[:total]).to eq(1)
+        rec = result[:recommendations].first
+        expect(rec[:course][:subject]).to eq("COMP")
+        expect(rec[:course][:course_number]).to eq(2000)
+        expect(rec[:course][:title]).to eq("Data Structures")
+        expect(rec[:course][:crn]).to eq(12345)
+        expect(rec[:course][:credits]).to eq(3)
+      end
+
+      it "marks prerequisite status as met when no prerequisites exist" do
+        result = described_class.call(user: user, term: term)
+
+        rec = result[:recommendations].first
+        expect(rec[:prerequisite_status]).to eq("met")
+      end
+    end
+
+    context "excluding planned courses" do
+      let!(:planned_course) do
+        create(:course, term: term, subject: "COMP", course_number: 2000, crn: 12345)
+      end
+      let!(:unplanned_course) do
+        create(:course, term: term, subject: "COMP", course_number: 3000, crn: 12346)
+      end
+
+      before do
+        create(:course_plan, user: user, term: term, course: planned_course,
+                             planned_subject: "COMP", planned_course_number: 2000,
+                             planned_crn: 12345, status: "planned")
+      end
+
+      it "excludes courses already in the user's plan" do
+        result = described_class.call(user: user, term: term)
+
+        course_numbers = result[:recommendations].map { |r| r[:course][:course_number] }
+        expect(course_numbers).not_to include(2000)
+        expect(course_numbers).to include(3000)
+      end
+    end
+
+    context "excluding completed courses" do
+      let!(:completed_course) do
+        create(:course, term: term, subject: "COMP", course_number: 1000, crn: 11111)
+      end
+      let!(:incomplete_course) do
+        create(:course, term: term, subject: "COMP", course_number: 2000, crn: 22222)
+      end
+
+      before do
+        req = create(:degree_requirement, degree_program: degree_program,
+                                          subject: "COMP", course_number: 1000)
+        create(:requirement_completion, user: user, degree_requirement: req,
+                                        subject: "COMP", course_number: 1000,
+                                        met_requirement: true, in_progress: false, grade: "A")
+      end
+
+      it "excludes courses the user has already completed" do
+        result = described_class.call(user: user, term: term)
+
+        course_numbers = result[:recommendations].map { |r| r[:course][:course_number] }
+        expect(course_numbers).not_to include(1000)
+        expect(course_numbers).to include(2000)
+      end
+    end
+
+    context "ranking by priority" do
+      let!(:required_course) do
+        create(:course, term: term, subject: "COMP", course_number: 2000, crn: 22222)
+      end
+      let!(:elective_course) do
+        create(:course, term: term, subject: "ARTS", course_number: 1000, crn: 33333)
+      end
+
+      before do
+        create(:degree_requirement, degree_program: degree_program,
+                                    subject: "COMP", course_number: 2000,
+                                    area_name: "Core CS Requirements")
+      end
+
+      it "puts required courses before electives" do
+        result = described_class.call(user: user, term: term)
+
+        expect(result[:recommendations].size).to eq(2)
+        expect(result[:recommendations].first[:priority]).to eq("required")
+        expect(result[:recommendations].first[:fulfills_requirement]).to eq("Core CS Requirements")
+        expect(result[:recommendations].last[:priority]).to eq("elective")
+        expect(result[:recommendations].last[:fulfills_requirement]).to be_nil
+      end
+    end
+
+    context "schedule conflict detection" do
+      let!(:planned_course) do
+        create(:course, term: term, subject: "COMP", course_number: 1500, crn: 11111)
+      end
+      let!(:conflicting_course) do
+        create(:course, term: term, subject: "COMP", course_number: 2000, crn: 22222)
+      end
+      let!(:non_conflicting_course) do
+        create(:course, term: term, subject: "COMP", course_number: 3000, crn: 33333)
+      end
+
+      before do
+        # planned course on Monday 9:00-10:00
+        create(:meeting_time, course: planned_course, day_of_week: :monday,
+                              begin_time: 900, end_time: 1000)
+        # conflicting course also Monday 9:30-10:30
+        create(:meeting_time, course: conflicting_course, day_of_week: :monday,
+                              begin_time: 930, end_time: 1030)
+        # non-conflicting on Tuesday
+        create(:meeting_time, course: non_conflicting_course, day_of_week: :tuesday,
+                              begin_time: 900, end_time: 1000)
+
+        create(:course_plan, user: user, term: term, course: planned_course,
+                             planned_subject: "COMP", planned_course_number: 1500,
+                             planned_crn: 11111, status: "planned")
+      end
+
+      it "detects schedule conflicts with planned courses" do
+        result = described_class.call(user: user, term: term)
+
+        recs_by_crn = result[:recommendations].index_by { |r| r[:course][:crn] }
+        expect(recs_by_crn[22222][:schedule_conflicts]).to be true
+        expect(recs_by_crn[33333][:schedule_conflicts]).to be false
+      end
+
+      it "ranks non-conflicting courses before conflicting ones" do
+        result = described_class.call(user: user, term: term)
+
+        crns = result[:recommendations].map { |r| r[:course][:crn] }
+        non_conflict_idx = crns.index(33333)
+        conflict_idx = crns.index(22222)
+        expect(non_conflict_idx).to be < conflict_idx
+      end
+    end
+
+    context "with RMP ratings" do
+      let(:faculty_high) { create(:faculty, first_name: "Good", last_name: "Prof", email: "good@wit.edu") }
+      let(:faculty_low) { create(:faculty, first_name: "Low", last_name: "Prof", email: "low@wit.edu") }
+
+      let!(:high_rated_course) do
+        course = create(:course, term: term, subject: "COMP", course_number: 3000, crn: 33333)
+        course.faculties << faculty_high
+        course
+      end
+      let!(:low_rated_course) do
+        course = create(:course, term: term, subject: "COMP", course_number: 4000, crn: 44444)
+        course.faculties << faculty_low
+        course
+      end
+
+      before do
+        create(:rating_distribution, faculty: faculty_high, avg_rating: 4.5, num_ratings: 20, total: 20)
+        create(:rating_distribution, faculty: faculty_low, avg_rating: 2.5, num_ratings: 10, total: 10)
+      end
+
+      it "includes faculty RMP rating in course data" do
+        result = described_class.call(user: user, term: term)
+
+        recs_by_crn = result[:recommendations].index_by { |r| r[:course][:crn] }
+        expect(recs_by_crn[33333][:course][:faculty][:rmp_rating]).to eq(4.5)
+        expect(recs_by_crn[44444][:course][:faculty][:rmp_rating]).to eq(2.5)
+      end
+
+      it "ranks higher-rated courses first within same priority" do
+        result = described_class.call(user: user, term: term)
+
+        crns = result[:recommendations].map { |r| r[:course][:crn] }
+        high_idx = crns.index(33333)
+        low_idx = crns.index(44444)
+        expect(high_idx).to be < low_idx
+      end
+    end
+
+    context "with cancelled courses" do
+      let!(:active_course) do
+        create(:course, term: term, subject: "COMP", course_number: 2000, crn: 22222, status: :active)
+      end
+      let!(:cancelled_course) do
+        create(:course, term: term, subject: "COMP", course_number: 3000, crn: 33333, status: :cancelled)
+      end
+
+      it "excludes cancelled courses" do
+        result = described_class.call(user: user, term: term)
+
+        crns = result[:recommendations].map { |r| r[:course][:crn] }
+        expect(crns).to include(22222)
+        expect(crns).not_to include(33333)
+      end
+    end
+
+    context "with no degree program" do
+      before do
+        UserDegreeProgram.where(user: user).destroy_all
+      end
+
+      let!(:course) do
+        create(:course, term: term, subject: "COMP", course_number: 2000, crn: 22222)
+      end
+
+      it "still returns courses as electives" do
+        result = described_class.call(user: user, term: term)
+
+        expect(result[:total]).to eq(1)
+        expect(result[:recommendations].first[:priority]).to eq("elective")
+      end
+    end
+
+    context "with no courses in term" do
+      it "returns empty recommendations" do
+        result = described_class.call(user: user, term: term)
+
+        expect(result[:recommendations]).to be_empty
+        expect(result[:total]).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Implements `CourseRecommendationService` that recommends courses based on unfulfilled degree requirements, prerequisite eligibility, schedule conflicts, and RMP ratings
- Adds `GET /api/users/me/course_recommendations?term_uid=XXXXXX` API endpoint
- Comprehensive test coverage: 13 service specs + 7 request specs (20 total, all passing)

## How it works
1. Finds active courses for the given term
2. Excludes courses already in the user's plan and already-completed courses
3. Checks prerequisite eligibility via `PrerequisiteValidationService`
4. Matches courses to unfulfilled `DegreeRequirement` records
5. Detects schedule conflicts with planned courses
6. Ranks: required courses first, then electives; within each: no conflicts first, then by RMP rating

Closes #340
Part of #335

PR assisted by Claude