### PR TITLE
feat: course enrollment seat counts (#355)

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -5,22 +5,24 @@
 # Table name: courses
 # Database name: primary
 #
-#  id             :bigint           not null, primary key
-#  course_number  :integer
-#  credit_hours   :integer
-#  crn            :integer
-#  embedding      :vector(1536)
-#  end_date       :date
-#  grade_mode     :string
-#  schedule_type  :string           not null
-#  section_number :string           not null
-#  start_date     :date
-#  status         :string           default("active"), not null
-#  subject        :string
-#  title          :string
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  term_id        :bigint           not null
+#  id              :bigint           not null, primary key
+#  course_number   :integer
+#  credit_hours    :integer
+#  crn             :integer
+#  embedding       :vector(1536)
+#  end_date        :date
+#  grade_mode      :string
+#  schedule_type   :string           not null
+#  seats_available :integer
+#  seats_capacity  :integer
+#  section_number  :string           not null
+#  start_date      :date
+#  status          :string           default("active"), not null
+#  subject         :string
+#  title           :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  term_id         :bigint           not null
 #
 # Indexes
 #

--- a/app/serializers/course_suggestion_serializer.rb
+++ b/app/serializers/course_suggestion_serializer.rb
@@ -13,7 +13,9 @@ class CourseSuggestionSerializer
       crn: @course.crn,
       title: @course.title,
       credit_hours: @course.credit_hours,
-      schedule_type: @course.schedule_type
+      schedule_type: @course.schedule_type,
+      seats_available: @course.seats_available,
+      seats_capacity: @course.seats_capacity
     }
   end
 

--- a/app/services/course_processor_service.rb
+++ b/app/services/course_processor_service.rb
@@ -141,9 +141,12 @@ class CourseProcessorService < ApplicationService
         # Labs are typically 0-credit companion sections, so override for LAB schedule type
         c.credit_hours = schedule_type_match && schedule_type_match[1] == "LAB" ? 0 : detailed_course_info[:credit_hours]
         c.grade_mode = detailed_course_info[:grade_mode]
+        c.seats_available = detailed_course_info[:seats_available]
+        c.seats_capacity  = detailed_course_info[:seats_capacity]
       end
 
       # Update course if it already exists (title may have changed or need re-titleization)
+      # Seats are always updated since enrollment changes frequently.
       if course.persisted? && !course.new_record?
         update_attrs = {}
         update_attrs[:start_date] = start_date if start_date.present?
@@ -154,6 +157,10 @@ class CourseProcessorService < ApplicationService
           new_title = titleize_with_roman_numerals(detailed_course_info[:title])
           update_attrs[:title] = new_title if course.title != new_title
         end
+
+        # Always update seat counts — enrollment data changes frequently
+        update_attrs[:seats_available] = detailed_course_info[:seats_available] unless detailed_course_info[:seats_available].nil?
+        update_attrs[:seats_capacity]  = detailed_course_info[:seats_capacity]  unless detailed_course_info[:seats_capacity].nil?
 
         course.update!(update_attrs) if update_attrs.any?
       end

--- a/app/services/leopard_web_service.rb
+++ b/app/services/leopard_web_service.rb
@@ -116,6 +116,18 @@ class LeopardWebService < ApplicationService
       end.compact
     end
 
+    # Fetch enrollment/seat counts on the same stateful connection (no params required
+    # because getEnrollmentInfo uses the session context set by getClassDetails above).
+    begin
+      enrollment_data = get_enrollment_info
+      if enrollment_data
+        details[:seats_available] = enrollment_data.dig(:enrollment, :seats_available)
+        details[:seats_capacity]  = enrollment_data.dig(:enrollment, :maximum)
+      end
+    rescue => e
+      Rails.logger.warn("LeopardWebService: Failed to fetch enrollment info for CRN #{course_reference_number}: #{e.message}")
+    end
+
     details
   end
 

--- a/db/migrate/20260209224226_add_content_hash_to_degree_evaluation_snapshots.rb
+++ b/db/migrate/20260209224226_add_content_hash_to_degree_evaluation_snapshots.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class AddContentHashToDegreeEvaluationSnapshots < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
   def change
     add_column :degree_evaluation_snapshots, :content_hash, :string
-    add_index :degree_evaluation_snapshots, :content_hash
+    add_index :degree_evaluation_snapshots, :content_hash, algorithm: :concurrently
   end
-
 end

--- a/db/migrate/20260223052551_add_seats_to_courses.rb
+++ b/db/migrate/20260223052551_add_seats_to_courses.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddSeatsToCourses < ActiveRecord::Migration[8.1]
+  def change
+    add_column :courses, :seats_available, :integer
+    add_column :courses, :seats_capacity, :integer
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_10_003917) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_23_052551) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -274,6 +274,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_10_003917) do
     t.date "end_date"
     t.string "grade_mode"
     t.string "schedule_type", null: false
+    t.integer "seats_available"
+    t.integer "seats_capacity"
     t.string "section_number", null: false
     t.date "start_date"
     t.string "status", default: "active", null: false

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -5,22 +5,24 @@
 # Table name: courses
 # Database name: primary
 #
-#  id             :bigint           not null, primary key
-#  course_number  :integer
-#  credit_hours   :integer
-#  crn            :integer
-#  embedding      :vector(1536)
-#  end_date       :date
-#  grade_mode     :string
-#  schedule_type  :string           not null
-#  section_number :string           not null
-#  start_date     :date
-#  status         :string           default("active"), not null
-#  subject        :string
-#  title          :string
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  term_id        :bigint           not null
+#  id              :bigint           not null, primary key
+#  course_number   :integer
+#  credit_hours    :integer
+#  crn             :integer
+#  embedding       :vector(1536)
+#  end_date        :date
+#  grade_mode      :string
+#  schedule_type   :string           not null
+#  seats_available :integer
+#  seats_capacity  :integer
+#  section_number  :string           not null
+#  start_date      :date
+#  status          :string           default("active"), not null
+#  subject         :string
+#  title           :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  term_id         :bigint           not null
 #
 # Indexes
 #


### PR DESCRIPTION
## Summary

- Adds `seats_available` and `seats_capacity` integer columns to the `courses` table
- `LeopardWebService#get_class_details` now fetches enrollment data on the same stateful HTTP connection (since `getEnrollmentInfo` is session-based and requires a prior `getClassDetails` call on the same instance)
- `CourseProcessorService` sets seat counts on course creation and **always** updates them on re-process since enrollment fluctuates throughout the term
- `CourseDataSyncJob` always updates seat counts even when no other course data changed
- `CourseSuggestionSerializer` exposes `seats_available`/`seats_capacity` in the recommendations API response

## Test plan

- [x] `bundle exec rspec spec/services/leopard_web_service_spec.rb` — includes tests for enrollment data in `get_class_details` result and graceful degradation when enrollment fetch fails
- [x] `bundle exec rspec spec/services/course_processor_service_spec.rb` — includes tests for seats set on new courses and updated on existing ones
- [x] `bundle exec rspec spec/jobs/course_data_sync_job_spec.rb` — includes tests for `update_enrollment_counts` and that seats always update even with no other changes

PR assisted by Claude