### PR TITLE
fix email not displaying in the description for ics calendars

### DIFF
--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -6,7 +6,7 @@ class CalendarsController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def show
-    @user = User.find_by!(calendar_token: params[:calendar_token])
+    @user = User.includes(:emails).find_by!(calendar_token: params[:calendar_token])
 
     # Get all enrolled courses with meeting times
     @courses = @user.courses


### PR DESCRIPTION
**The Problem**
In `calendars_controller.rb`:

- The user was loaded without including the `emails` association
- When `@user.email` was called, it could return nil if no primary email exists
- This resulted in the calendar description being incomplete: "WIT Course Schedule Calendar for " (empty)

**The Fix**
Load the `emails` association with the `user`:

`@user = User.includes(:emails).find_by!(calendar_token: params[:calendar_token])`