### PR TITLE
fix final exams in ics calendar still displaying locations with the abbreviations

### DIFF
--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -214,7 +214,7 @@ class CalendarsController < ApplicationController
 
         e.summary = "Final Exam: #{titleize_with_roman_numerals(final_exam.course_title)}"
         e.description = final_exam.course_code
-        e.location = final_exam.location if final_exam.location.present?
+        e.location = final_exam.location_with_names if final_exam.location.present?
 
         # Stable UID for final exams
         e.uid = "final-exam-#{final_exam.id}@calendar-util.wit.edu"

--- a/app/models/concerns/course_schedule_syncable.rb
+++ b/app/models/concerns/course_schedule_syncable.rb
@@ -513,7 +513,7 @@ module CourseScheduleSyncable
     event = {
       summary: "Final Exam: #{final_exam.course_title}",
       description: final_exam.course_code,
-      location: final_exam.location,
+      location: final_exam.location_with_names,
       start_time: final_exam.start_datetime,
       end_time: final_exam.end_datetime,
       course_code: final_exam.course_code,


### PR DESCRIPTION
Closes #406 