### PR TITLE
fix: filter ONLINE entries from EXAM-ROOM column to prevent room misalignment (#415)

### DIFF
--- a/app/services/finals_schedule_parsers/spring_2026_parser.rb
+++ b/app/services/finals_schedule_parsers/spring_2026_parser.rb
@@ -63,8 +63,10 @@ module FinalsScheduleParsers
           when :exam_room
             # extract_location filters out cross-page noise (page footers, course
             # section codes, titles, etc.) while collecting valid room strings.
+            # Exclude no-exam markers (ONLINE, SEE FACULTY, TBA) so all_rooms stays
+            # the same length as all_times (both M ≤ N), keeping time_room_idx aligned.
             loc = extract_location(line)
-            all_rooms << loc if loc
+            all_rooms << loc if loc && !no_exam_entry?(loc)
           end
         end
       end

--- a/spec/services/finals_schedule_parsers/spring_2026_parser_spec.rb
+++ b/spec/services/finals_schedule_parsers/spring_2026_parser_spec.rb
@@ -147,6 +147,46 @@ RSpec.describe FinalsScheduleParsers::Spring2026Parser do
       end
     end
 
+    context "ONLINE entry also appears in EXAM-ROOM column (does not corrupt alignment)" do
+      let(:text) do
+        <<~TEXT
+          CRN
+          29416
+          29452
+          29465
+
+          INSTRUCTOR
+          Kim, Lora
+          Peters, Troy
+          Crossley, Tatjana
+
+          EXAM-DATE
+          Friday, April 10, 2026
+          ONLINE
+          Monday, April 13, 2026
+
+          EXAM-TIME-OF-DAY
+          10:15 AM - 12:15 PM
+          12:45 PM - 2:45 PM
+
+          EXAM-ROOM
+          WENTW 205
+          ONLINE
+          RBSTN 201
+        TEXT
+      end
+
+      it "skips the ONLINE course" do
+        expect(entries.length).to eq(2)
+        expect(entries.pluck(:crn)).to contain_exactly(29416, 29465)
+      end
+
+      it "assigns the correct room to the post-ONLINE entry" do
+        post_online = entries.find { |e| e[:crn] == 29465 }
+        expect(post_online[:location]).to eq("RBSTN 201")
+      end
+    end
+
     context "SEE FACULTY course mixed with regular courses" do
       let(:text) do
         <<~TEXT


### PR DESCRIPTION
## Summary

- Fixes room misalignment in the Spring 2026 finals parser where ONLINE entries in the EXAM-ROOM column shifted `all_rooms` out of sync with `all_times`
- Adds `!no_exam_entry?(loc)` guard to the `:exam_room` state, mirroring the existing guard on `:exam_time`
- Adds a regression test covering the ONLINE-in-EXAM-ROOM scenario

## Test plan
- [ ] `bundle exec rspec spec/services/finals_schedule_parsers/spring_2026_parser_spec.rb` — all 19 examples pass
- [ ] After deploy, re-import the Spring 2026 finals PDF via the admin panel to fix currently misaligned records in production

PR assisted by Claude