### PR TITLE
perf: fix N+1 queries and add auto-migration on deploy

### DIFF
--- a/.kamal/hooks/pre-app-boot
+++ b/.kamal/hooks/pre-app-boot
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "Running database migrations before boot..."
+kamal app exec --reuse --roles=web "bin/rails db:migrate"

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -20,13 +20,15 @@ module Admin
         if search_term.match?(/^\d+$/)
           @users = @users.where(id: search_term.to_i)
         else
-          # Search by email (through emails table) or concatenated first+last name
-          @users = @users.joins(:emails).where(
-            "emails.email ILIKE :search OR " \
-            "CONCAT(users.first_name, users.last_name) ILIKE :search OR " \
-            "CONCAT(users.first_name, ' ', users.last_name) ILIKE :search",
-            search: "%#{search_term}%"
-          ).distinct
+          # Search by email (through emails table) or concatenated first+last name.
+          # Use a subquery for email matching to avoid JOIN + DISTINCT interfering with pagination counts.
+          name_search = "%#{search_term}%"
+          email_matched = @users.joins(:emails).where("emails.email ILIKE ?", name_search).select(:id)
+          name_matched = @users.where(
+            "CONCAT(users.first_name, users.last_name) ILIKE ? OR CONCAT(users.first_name, ' ', users.last_name) ILIKE ?",
+            name_search, name_search
+          )
+          @users = @users.where(id: email_matched).or(name_matched)
         end
       end
 

--- a/app/controllers/api/calendar_preferences_controller.rb
+++ b/app/controllers/api/calendar_preferences_controller.rb
@@ -68,9 +68,13 @@ module Api
         return
       end
 
-      # Accept both internal ID and public_id
-      meeting_time = find_by_any_id(MeetingTime, meeting_time_id)
-      meeting_time = MeetingTime.includes(course: :faculties).find_by(id: meeting_time&.id) if meeting_time
+      # Accept both internal ID and public_id, eager-load associations in one query
+      scope = MeetingTime.includes(course: :faculties)
+      meeting_time = if meeting_time_id.to_s.include?("_")
+                       scope.find_by_public_id(meeting_time_id)
+                     else
+                       scope.find_by(id: meeting_time_id)
+                     end
       unless meeting_time
         render json: { error: "Meeting time not found" }, status: :not_found
         return

--- a/app/controllers/api/event_preferences_controller.rb
+++ b/app/controllers/api/event_preferences_controller.rb
@@ -106,13 +106,21 @@ module Api
 
     def set_preferenceable
       if params[:meeting_time_id]
-        # Accept both internal ID and public_id, use eager_load for associations
-        @preferenceable = find_by_any_id!(MeetingTime, params[:meeting_time_id])
-        @preferenceable = MeetingTime.eager_load(course: :faculties, room: :building).find(@preferenceable.id)
+        id = params[:meeting_time_id]
+        scope = MeetingTime.eager_load(course: :faculties, room: :building)
+        @preferenceable = if id.to_s.include?("_")
+                            scope.find_by_public_id!(id) # rubocop:disable Rails/DynamicFindBy
+                          else
+                            scope.find(id)
+                          end
       elsif params[:google_calendar_event_id]
-        # Accept both internal ID and public_id, use eager_load for associations
-        @preferenceable = find_by_any_id!(GoogleCalendarEvent, params[:google_calendar_event_id])
-        @preferenceable = GoogleCalendarEvent.eager_load(meeting_time: { course: :faculties, room: :building }).find(@preferenceable.id)
+        id = params[:google_calendar_event_id]
+        scope = GoogleCalendarEvent.eager_load(meeting_time: { course: :faculties, room: :building })
+        @preferenceable = if id.to_s.include?("_")
+                            scope.find_by_public_id!(id) # rubocop:disable Rails/DynamicFindBy
+                          else
+                            scope.find(id)
+                          end
       else
         render json: { error: "Preferenceable not specified" }, status: :bad_request
       end

--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -10,7 +10,7 @@ class CalendarsController < ApplicationController
 
     # Get all enrolled courses with meeting times
     @courses = @user.courses
-                    .includes(:meeting_times, :term, meeting_times: [:room, :building])
+                    .includes(:term, meeting_times: [:room, :building, { course: [:faculties, :term] }])
 
     # Get final exams for enrolled courses
     @final_exams = FinalExam.where(course_id: @courses.pluck(:id))
@@ -40,8 +40,8 @@ class CalendarsController < ApplicationController
     @preference_resolver = PreferenceResolver.new(@user)
     @template_renderer = CalendarTemplateRenderer.new
 
-    # Cache holidays for EXDATE generation
-    @holidays_cache = {}
+    # Pre-load holidays for EXDATE generation (single query across all meeting time ranges)
+    @holidays_cache = preload_holidays_cache(courses)
     # Cache finals dates so we avoid N+1 queries in recurrence rule building
     @ics_course_finals_cache = {}
     @ics_term_finals_cache = {}
@@ -284,6 +284,25 @@ class CalendarsController < ApplicationController
         e.append_custom_property("X-MICROSOFT-CDO-ALLDAYEVENT", "TRUE")
         e.append_custom_property("X-MICROSOFT-CDO-BUSYSTATUS", "FREE")
         e.transp = "TRANSPARENT" # Show as "free" time
+      end
+    end
+  end
+
+  # Pre-load all holiday/finals events covering every meeting time's date range in a single query.
+  # Returns a hash keyed by [start_date, end_date] → array of matching events.
+  def preload_holidays_cache(courses)
+    meeting_times = courses.flat_map { |c| c.meeting_times.to_a }
+    return {} if meeting_times.empty?
+
+    min_date = meeting_times.filter_map(&:start_date).min
+    max_date = meeting_times.filter_map(&:end_date).max
+    return {} unless min_date && max_date
+
+    all_no_class_days = UniversityCalendarEvent.no_class_days_between(min_date, max_date).to_a
+
+    meeting_times.map { |mt| [mt.start_date, mt.end_date] }.uniq.each_with_object({}) do |(start_date, end_date), cache|
+      cache[[start_date, end_date]] = all_no_class_days.select do |h|
+        h.start_time.to_date <= end_date && h.end_time.to_date >= start_date
       end
     end
   end

--- a/db/migrate/20260311145117_add_index_to_friendships_addressee_requester.rb
+++ b/db/migrate/20260311145117_add_index_to_friendships_addressee_requester.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddIndexToFriendshipsAddresseeRequester < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :friendships, [:addressee_id, :requester_id],
+              name: "index_friendships_on_addressee_id_and_requester_id",
+              algorithm: :concurrently
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_23_052551) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_11_145117) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -501,6 +501,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_23_052551) do
     t.bigint "requester_id", null: false
     t.integer "status", default: 0, null: false
     t.datetime "updated_at", null: false
+    t.index ["addressee_id", "requester_id"], name: "index_friendships_on_addressee_id_and_requester_id"
     t.index ["addressee_id", "status"], name: "index_friendships_on_addressee_id_and_status"
     t.index ["addressee_id"], name: "index_friendships_on_addressee_id"
     t.index ["requester_id", "addressee_id"], name: "index_friendships_on_requester_id_and_addressee_id", unique: true
@@ -815,6 +816,107 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_23_052551) do
     t.index ["name"], name: "index_transfer_universities_on_name"
   end
 
+  create_table "twenty_five_live_categories", force: :cascade do |t|
+    t.integer "category_id", null: false
+    t.string "category_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_twenty_five_live_categories_on_category_id", unique: true
+  end
+
+  create_table "twenty_five_live_event_categories", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "twenty_five_live_category_id", null: false
+    t.bigint "twenty_five_live_event_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["twenty_five_live_category_id"], name: "idx_on_twenty_five_live_category_id_c676dbdbc3"
+    t.index ["twenty_five_live_event_id", "twenty_five_live_category_id"], name: "index_tfl_event_cats_on_event_and_cat", unique: true
+    t.index ["twenty_five_live_event_id"], name: "idx_on_twenty_five_live_event_id_fbaea0ece2"
+  end
+
+  create_table "twenty_five_live_event_organizations", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.boolean "primary", default: false, null: false
+    t.bigint "twenty_five_live_event_id", null: false
+    t.bigint "twenty_five_live_organization_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["twenty_five_live_event_id", "twenty_five_live_organization_id"], name: "index_tfl_event_orgs_on_event_and_org", unique: true
+    t.index ["twenty_five_live_event_id"], name: "idx_on_twenty_five_live_event_id_90d70194d5"
+    t.index ["twenty_five_live_organization_id"], name: "idx_on_twenty_five_live_organization_id_829b355159"
+  end
+
+  create_table "twenty_five_live_events", force: :cascade do |t|
+    t.integer "cabinet_id"
+    t.string "cabinet_name"
+    t.datetime "created_at", null: false
+    t.datetime "creation_dt"
+    t.text "description"
+    t.date "end_date"
+    t.integer "event_id", null: false
+    t.string "event_locator", null: false
+    t.string "event_name", null: false
+    t.string "event_title"
+    t.integer "event_type_id"
+    t.string "event_type_name"
+    t.datetime "last_mod_dt"
+    t.datetime "last_synced_at"
+    t.boolean "public_website", default: false, null: false
+    t.string "registration_url"
+    t.date "start_date"
+    t.integer "state"
+    t.string "state_name"
+    t.datetime "updated_at", null: false
+    t.index ["event_id"], name: "index_twenty_five_live_events_on_event_id", unique: true
+    t.index ["event_locator"], name: "index_twenty_five_live_events_on_event_locator", unique: true
+  end
+
+  create_table "twenty_five_live_organizations", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "organization_id", null: false
+    t.string "organization_name"
+    t.string "organization_title"
+    t.integer "organization_type_id"
+    t.string "organization_type_name"
+    t.datetime "updated_at", null: false
+    t.index ["organization_id"], name: "index_twenty_five_live_organizations_on_organization_id", unique: true
+  end
+
+  create_table "twenty_five_live_reservations", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "event_end_dt"
+    t.datetime "event_start_dt"
+    t.integer "expected_count"
+    t.integer "reservation_id", null: false
+    t.integer "reservation_state"
+    t.bigint "twenty_five_live_event_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["reservation_id"], name: "index_twenty_five_live_reservations_on_reservation_id", unique: true
+    t.index ["twenty_five_live_event_id"], name: "idx_on_twenty_five_live_event_id_27330189d9"
+  end
+
+  create_table "twenty_five_live_space_reservations", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "layout_id"
+    t.string "layout_name"
+    t.integer "selected_layout_capacity"
+    t.bigint "twenty_five_live_reservation_id", null: false
+    t.bigint "twenty_five_live_space_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["twenty_five_live_reservation_id"], name: "idx_on_twenty_five_live_reservation_id_36a801db84"
+    t.index ["twenty_five_live_space_id"], name: "idx_on_twenty_five_live_space_id_eb37f1572a"
+  end
+
+  create_table "twenty_five_live_spaces", force: :cascade do |t|
+    t.string "building_name"
+    t.datetime "created_at", null: false
+    t.string "formal_name"
+    t.integer "max_capacity"
+    t.integer "space_id", null: false
+    t.string "space_name"
+    t.datetime "updated_at", null: false
+    t.index ["space_id"], name: "index_twenty_five_live_spaces_on_space_id", unique: true
+  end
+
   create_table "university_calendar_events", force: :cascade do |t|
     t.string "academic_term"
     t.boolean "all_day", default: false, null: false
@@ -946,6 +1048,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_23_052551) do
   add_foreign_key "transfer_courses", "transfer_universities", column: "university_id"
   add_foreign_key "transfer_equivalencies", "courses", column: "wit_course_id"
   add_foreign_key "transfer_equivalencies", "transfer_courses"
+  add_foreign_key "twenty_five_live_event_categories", "twenty_five_live_categories"
+  add_foreign_key "twenty_five_live_event_categories", "twenty_five_live_events"
+  add_foreign_key "twenty_five_live_event_organizations", "twenty_five_live_events"
+  add_foreign_key "twenty_five_live_event_organizations", "twenty_five_live_organizations"
+  add_foreign_key "twenty_five_live_reservations", "twenty_five_live_events"
+  add_foreign_key "twenty_five_live_space_reservations", "twenty_five_live_reservations"
+  add_foreign_key "twenty_five_live_space_reservations", "twenty_five_live_spaces"
   add_foreign_key "university_calendar_events", "terms"
   add_foreign_key "user_degree_programs", "degree_programs"
   add_foreign_key "user_degree_programs", "users"


### PR DESCRIPTION
## Summary

- **ICS feed**: preload `course.faculties` and `course.term` via `meeting_times` includes to prevent N+1 in `CalendarTemplateRenderer`; replace lazy per-meeting-time holiday queries with a single pre-loaded query across the full date range
- **calendar_preferences / event_preferences**: eliminate double-query pattern (find → reload with eager_load) by chaining `includes`/`eager_load` directly on the scoped lookup in one query
- **Admin user search**: replace `JOIN + DISTINCT` with a subquery + `.or()` to fix pagination count interference with kaminari
- **Friendships index**: add `[addressee_id, requester_id]` composite index for reverse-direction lookups (migration runs concurrently)
- **Kamal deploy hook**: add `pre-app-boot` hook so `db:migrate` runs automatically on every deploy

## Test plan

- [ ] Run `bundle exec rspec spec/requests/calendars_spec.rb` — existing passing tests still pass
- [ ] Run `bundle exec rspec spec/requests/api/calendar_preferences_spec.rb spec/requests/api/event_preferences_spec.rb` — all pass
- [ ] Verify ICS feed loads correctly in a calendar client
- [ ] Verify admin user search still works with email and name queries
- [ ] Deploy to prod and confirm migration runs automatically via the new hook

PR assisted by Claude