### PR TITLE
fix: return proper status codes for invalid URLs and missing routes

### DIFF
--- a/app/controllers/api/catch_all_controller.rb
+++ b/app/controllers/api/catch_all_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Api
+  class CatchAllController < ApiController
+    def not_found
+      render json: { error: "Not found" }, status: :not_found
+    end
+  end
+end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -10,4 +10,12 @@ class ErrorsController < ApplicationController
   def not_found
     render status: :not_found
   end
+
+  def unprocessable_entity
+    render status: :unprocessable_entity
+  end
+
+  def internal_server_error
+    render status: :internal_server_error
+  end
 end

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>500 Internal Server Error</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 flex items-center justify-center">
+  <div class="text-center px-6">
+    <div class="inline-flex items-center justify-center w-24 h-24 bg-red-100 rounded-full mb-6">
+      <svg class="w-12 h-12 text-[#d13732]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+      </svg>
+    </div>
+    <h1 class="text-6xl font-bold text-gray-900 mb-2">500</h1>
+    <h2 class="text-2xl font-semibold text-gray-700 mb-4">Something Went Wrong</h2>
+    <p class="text-gray-500 mb-8 max-w-md">An unexpected error occurred. Please try again later.</p>
+    <div class="flex gap-4 justify-center">
+      <%= link_to "Go Home", root_path, class: "px-6 py-2 bg-[#d13732] text-white rounded-lg hover:bg-[#b82e2a] transition font-medium" %>
+    </div>
+  </div>
+</body>
+</html>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>422 Unprocessable Entity</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 flex items-center justify-center">
+  <div class="text-center px-6">
+    <div class="inline-flex items-center justify-center w-24 h-24 bg-red-100 rounded-full mb-6">
+      <svg class="w-12 h-12 text-[#d13732]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+      </svg>
+    </div>
+    <h1 class="text-6xl font-bold text-gray-900 mb-2">422</h1>
+    <h2 class="text-2xl font-semibold text-gray-700 mb-4">Unprocessable Request</h2>
+    <p class="text-gray-500 mb-8 max-w-md">The request could not be processed. Please check your input and try again.</p>
+    <div class="flex gap-4 justify-center">
+      <%= link_to "Go Home", root_path, class: "px-6 py-2 bg-[#d13732] text-white rounded-lg hover:bg-[#b82e2a] transition font-medium" %>
+    </div>
+  </div>
+</body>
+</html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,5 +30,7 @@ module Calendar
     #
     config.time_zone = "Eastern Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.exceptions_app = self.routes
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,8 @@ Rails.application.routes.draw do
         post :sync
       end
     end
+
+    match "*path", to: "catch_all#not_found", via: :all
   end
 
   # User dashboard (session-authenticated, any signed-in user)
@@ -204,6 +206,8 @@ Rails.application.routes.draw do
 
   get "unauthorized", to: "errors#unauthorized"
   get "404",          to: "errors#not_found"
+  get "422",          to: "errors#unprocessable_entity"
+  get "500",          to: "errors#internal_server_error"
 
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"


### PR DESCRIPTION
## Summary

- **Root cause**: No `config.exceptions_app` was set, so `ActionController::RoutingError` hit Rails' default `PublicExceptions` handler. With no `public/404.html` present, it fell through to a 500.
- **API catch-all**: Added `match "*path"` inside `namespace :api` → `Api::CatchAllController#not_found` returning `{ error: "Not found" }` JSON with 404. This catches unmatched `/api/*` paths before a RoutingError is ever raised.
- **exceptions_app**: Set `config.exceptions_app = self.routes` so non-API routing errors and other framework exceptions (invalid CSRF token → 422, etc.) flow through our router.
- **Missing error routes**: Added `/422` and `/500` routes, controller actions, and matching HTML views alongside the existing `/404`.

## Changes

| File | Change |
|------|--------|
| `config/application.rb` | Add `config.exceptions_app = self.routes` |
| `config/routes.rb` | Add API catch-all + `/422` + `/500` routes |
| `app/controllers/errors_controller.rb` | Add `unprocessable_entity` and `internal_server_error` actions |
| `app/controllers/api/catch_all_controller.rb` | New — JSON 404 for unmatched API paths |
| `app/views/errors/unprocessable_entity.html.erb` | New — 422 HTML error page |
| `app/views/errors/internal_server_error.html.erb` | New — 500 HTML error page |

## Test plan

- [ ] `GET /nonexistent-path` → 404 HTML page
- [ ] `GET /api/nonexistent` → `{ "error": "Not found" }` with 404 JSON
- [ ] `GET /api/user/id` with bad JWT → 401 JSON (existing behavior unchanged)
- [ ] Valid routes continue to work normally