### PR TITLE
fix: allow admin add-friend by email or user ID

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -132,15 +132,20 @@ module Admin
     def add_friend
       authorize @user, :manage_friendships?
 
-      friend_id = params[:friend_id]
-      if friend_id.blank?
-        redirect_to admin_user_path(@user), alert: "Friend ID is required."
+      friend_ref = params[:friend_id].to_s.strip
+      if friend_ref.blank?
+        redirect_to admin_user_path(@user), alert: "Friend email or user ID is required."
         return
       end
 
-      friend = User.find_by_public_id(friend_id)
+      friend = if friend_ref.include?("@")
+                 User.find_by(email: friend_ref.downcase)
+      else
+                 User.find_by_public_id(friend_ref)
+      end
+
       if friend.nil?
-        redirect_to admin_user_path(@user), alert: "User not found with ID: #{friend_id}"
+        redirect_to admin_user_path(@user), alert: "User not found: #{friend_ref}"
         return
       end
 

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -111,8 +111,8 @@
             <h3 class="text-sm font-medium text-on-surface-variant mb-2">Add Friend</h3>
             <%= form_with url: add_friend_admin_user_path(@user), method: :post, class: "flex gap-2 items-end" do |f| %>
               <div class="flex-1">
-                <label class="block text-xs text-on-surface-variant mb-1">Friend's User ID (usr_...)</label>
-                <%= f.text_field :friend_id, placeholder: "usr_abc123", class: "w-full px-3 py-2 text-sm border border-outline-variant rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:ring-opacity-50" %>
+                <label class="block text-xs text-on-surface-variant mb-1">Email or user ID</label>
+                <%= f.text_field :friend_id, placeholder: "email@wit.edu or usr_abc123", class: "w-full px-3 py-2 text-sm border border-outline-variant rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:ring-opacity-50" %>
               </div>
               <%= f.submit "Add Friend", class: "px-4 py-2 text-sm bg-primary text-white rounded-md hover:opacity-90 cursor-pointer" %>
             <% end %>


### PR DESCRIPTION
## Summary
- Admin user show "Add Friend" only resolved `usr_…` public IDs via `find_by_public_id`, so emails always failed.
- Resolve by email when the input contains `@`, otherwise keep public ID lookup.
- Update the form label/placeholder to advertise email or user ID.

Follow-up to #428 (API `friend_email` was already done; admin UI was not).

## Test plan
- [ ] On admin user show, add a friend by email → succeeds
- [ ] Add a friend by `usr_…` ID → still works
- [ ] Blank / unknown email or ID → clear alert
- [ ] Self-add / already friends → same alerts as before