### PR TITLE
feat: add public csv reporting endpoint for bi tools

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "csv"
+
+# Public read-only CSV exports for BI tools (Power BI Web connector, Excel).
+# Course schedule data only — never expose user data through these reports.
+class ReportsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  MEETING_TIMES_HEADERS = %w[
+    term_uid term crn subject course_number section_number title
+    schedule_type status seats_capacity seats_available
+    day day_of_week begin_time end_time meeting_type
+  ].freeze
+
+  def meeting_times
+    scope = Course::MeetingTime.joins(course: :term)
+    scope = scope.where(terms: { uid: params[:term_uid] }) if params[:term_uid].present?
+
+    rows = scope
+           .order(Arel.sql("terms.uid, courses.crn, course_meeting_times.day_of_week, course_meeting_times.begin_time"))
+           .pluck(
+             "terms.uid", "terms.season", "terms.year",
+             "courses.crn", "courses.subject", "courses.course_number",
+             "courses.section_number", "courses.title", "courses.schedule_type",
+             "courses.status", "courses.seats_capacity", "courses.seats_available",
+             "course_meeting_times.day_of_week",
+             "course_meeting_times.begin_time", "course_meeting_times.end_time",
+             "course_meeting_times.meeting_schedule_type"
+           )
+
+    expires_in 1.hour, public: true
+    send_data build_meeting_times_csv(rows), type: "text/csv; charset=utf-8",
+                                             filename: "meeting_times.csv", disposition: "inline"
+  end
+
+  private
+
+  def build_meeting_times_csv(rows)
+    CSV.generate do |csv|
+      csv << MEETING_TIMES_HEADERS
+
+      rows.each do |uid, season, year, crn, subject, course_number, section_number, title,
+                    schedule_type, status, seats_capacity, seats_available,
+                    day_of_week, begin_time, end_time, meeting_schedule_type|
+        # pluck type-casts enum columns, so season/day_of_week/meeting_schedule_type
+        # arrive as their string keys ("fall", "monday", "lecture")
+        csv << [
+          uid, "#{season.capitalize} #{year}",
+          crn, subject, course_number, section_number, title,
+          schedule_type, status, seats_capacity, seats_available,
+          day_of_week, Course::MeetingTime.day_of_weeks.fetch(day_of_week),
+          format_hhmm(begin_time), format_hhmm(end_time),
+          meeting_schedule_type
+        ]
+      end
+    end
+  end
+
+  # begin_time/end_time are stored as HHMM integers (e.g. 1350 => "13:50")
+  def format_hhmm(hhmm)
+    format("%02d:%02d", hhmm / 100, hhmm % 100)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,9 @@ Rails.application.routes.draw do
   # ICS calendar feed (public, token-gated)
   get "/calendar/:calendar_token", to: "calendars#show", as: :calendar, defaults: { format: :ics }
 
+  # Public CSV exports for BI tools (Power BI Web connector)
+  get "/reports/meeting_times", to: "reports#meeting_times", as: :meeting_times_report, defaults: { format: :csv }
+
   # Google RISC cross-account protection webhook
   post "/risc/events", to: "risc#create", as: :risc_events
 

--- a/spec/requests/reports_spec.rb
+++ b/spec/requests/reports_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Reports", type: :request do
+  describe "GET /reports/meeting_times" do
+    let!(:fall_term)   { Term.create!(uid: 202710, year: 2026, season: :fall) }
+    let!(:spring_term) { Term.create!(uid: 202620, year: 2026, season: :spring) }
+
+    let!(:fall_course) do
+      fall_term.courses.create!(
+        crn: 12345, subject: "Computer Science", course_number: 3100,
+        section_number: "01", title: "Algorithms", schedule_type: :lecture,
+        seats_capacity: 30, seats_available: 5,
+        start_date: Date.new(2026, 9, 8), end_date: Date.new(2026, 12, 15)
+      )
+    end
+
+    let!(:spring_course) do
+      spring_term.courses.create!(
+        crn: 54321, subject: "Mathematics", course_number: 2025,
+        section_number: "02", title: "Linear Algebra", schedule_type: :laboratory,
+        seats_capacity: 24, seats_available: 0,
+        start_date: Date.new(2026, 1, 12), end_date: Date.new(2026, 4, 20)
+      )
+    end
+
+    let!(:fall_meeting) do
+      fall_course.meeting_times.create!(
+        begin_time: 900, end_time: 1050, day_of_week: :monday,
+        meeting_schedule_type: :lecture, meeting_type: :class_meeting,
+        start_date: fall_course.start_date, end_date: fall_course.end_date
+      )
+    end
+
+    let!(:spring_meeting) do
+      spring_course.meeting_times.create!(
+        begin_time: 1350, end_time: 1550, day_of_week: :thursday,
+        meeting_schedule_type: :laboratory, meeting_type: :class_meeting,
+        start_date: spring_course.start_date, end_date: spring_course.end_date
+      )
+    end
+
+    it "returns a CSV of all meeting times" do
+      get "/reports/meeting_times"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("text/csv")
+
+      csv = CSV.parse(response.body, headers: true)
+      expect(csv.length).to eq(2)
+
+      row = csv.find { |r| r["crn"] == "12345" }
+      expect(row.to_h).to include(
+        "term_uid"       => "202710",
+        "term"           => "Fall 2026",
+        "subject"        => "Computer Science",
+        "course_number"  => "3100",
+        "section_number" => "01",
+        "title"          => "Algorithms",
+        "schedule_type"  => "lecture",
+        "status"         => "active",
+        "seats_capacity" => "30",
+        "seats_available" => "5",
+        "day"            => "monday",
+        "day_of_week"    => "1",
+        "begin_time"     => "09:00",
+        "end_time"       => "10:50",
+        "meeting_type"   => "lecture"
+      )
+    end
+
+    it "filters by term_uid" do
+      get "/reports/meeting_times", params: { term_uid: 202620 }
+
+      csv = CSV.parse(response.body, headers: true)
+      expect(csv.length).to eq(1)
+      expect(csv.first["crn"]).to eq("54321")
+      expect(csv.first["term"]).to eq("Spring 2026")
+      expect(csv.first["begin_time"]).to eq("13:50")
+    end
+
+    it "returns only headers when the term has no data" do
+      get "/reports/meeting_times", params: { term_uid: 999999 }
+
+      expect(response).to have_http_status(:ok)
+      csv = CSV.parse(response.body, headers: true)
+      expect(csv.length).to eq(0)
+    end
+
+    it "sets public cache headers" do
+      get "/reports/meeting_times"
+
+      expect(response.headers["Cache-Control"]).to include("public")
+      expect(response.headers["Cache-Control"]).to include("max-age=3600")
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds a public, read-only CSV endpoint for BI tools:

```
GET /reports/meeting_times
GET /reports/meeting_times?term_uid=202710
```

One row per course meeting time, joined with the course and term. Columns: term_uid, term, crn, subject, course_number, section_number, title, schedule_type, status, seats_capacity, seats_available, day, day_of_week, begin_time, end_time, meeting_type.

## Why

Power BI Service can refresh from a public web URL with no on-premises gateway. The production database is on a private Docker network, so a direct connection is not possible. This endpoint lets Power BI (and Excel) pull schedule data on a schedule.

```mermaid
flowchart LR
    DB[(Postgres)] --> App[Rails app]
    App -->|/reports/meeting_times CSV| PBI[Power BI Service]
    PBI --> Report[Standing dashboard]
```

## Notes

- Course schedule data only. No user data, no PII.
- `Cache-Control: public, max-age=3600` limits load from refresh polling.
- Optional `term_uid` filter; unknown terms return only the header row.

## Test

- Request spec covers the full export, the `term_uid` filter, the empty-term case, and cache headers.
- `bundle exec rspec`: 32 examples, 0 failures. RuboCop clean.