### PR TITLE
fix: serve csv reports to non-browser clients

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
       safely_block (>= 1)
     bootsnap (1.24.6)
       msgpack (~> 1.2)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)
@@ -681,7 +681,7 @@ CHECKSUMS
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   blazer (3.5.0) sha256=734b883b843fbd6d5c9db7a09ec267a068f504908f2d01b94fce151bd00ad4e2
   bootsnap (1.24.6) sha256=c60bab88c70332290f0a2636a288f675299eb4f804a02a3c085b42eca9da164a
-  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
+  brakeman (8.0.6) sha256=759cc69341115e6c2dcd47b6fd8649a0b9bd540e3585ac8a0a94e31c66fee386
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -4,9 +4,10 @@ require "csv"
 
 # Public read-only CSV exports for BI tools (Power BI Web connector, Excel).
 # Course schedule data only — never expose user data through these reports.
-class ReportsController < ApplicationController
-  skip_before_action :verify_authenticity_token
-
+#
+# Inherits ActionController::Base, not ApplicationController: consumers are
+# data tools (Power BI, curl), so the allow_browser check must not run here.
+class ReportsController < ActionController::Base
   MEETING_TIMES_HEADERS = %w[
     term_uid term crn subject course_number section_number title
     schedule_type status seats_capacity seats_available

--- a/public/406-unsupported-browser.html
+++ b/public/406-unsupported-browser.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Your browser is not supported</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      display: grid;
+      place-items: center;
+      min-height: 100vh;
+      margin: 0;
+      background: #f9fafb;
+      color: #111827;
+    }
+    main {
+      max-width: 26rem;
+      padding: 2rem;
+      text-align: center;
+    }
+    h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
+    p { color: #4b5563; line-height: 1.5; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Your browser is not supported</h1>
+    <p>Please update your browser to the latest version to use this site.</p>
+  </main>
+</body>
+</html>

--- a/spec/requests/reports_spec.rb
+++ b/spec/requests/reports_spec.rb
@@ -88,6 +88,14 @@ RSpec.describe "Reports", type: :request do
       expect(csv.length).to eq(0)
     end
 
+    it "serves non-browser clients such as Power BI and curl" do
+      get "/reports/meeting_times", headers: { "User-Agent" => "curl/8.7.1" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("text/csv")
+      expect(CSV.parse(response.body, headers: true).length).to eq(2)
+    end
+
     it "sets public cache headers" do
       get "/reports/meeting_times"
 


### PR DESCRIPTION
## What

- `ReportsController` now inherits `ActionController::Base` instead of `ApplicationController`. The `allow_browser` check no longer runs for the CSV endpoint.
- Adds the missing `public/406-unsupported-browser.html`. Before this, any blocked client got a 500 instead of a 406.
- Bumps brakeman to 8.0.6. `bin/brakeman --ensure-latest` failed CI after the upstream release.

## Why

`/reports/meeting_times` returned 500 in production for curl and Power BI. `allow_browser versions: :modern` blocked the non-browser user agent. The 406 render then crashed because the page file did not exist. Request specs missed this because Rails test requests send a modern browser user agent.

## Test

- New spec: the endpoint serves a request with a `curl/8.7.1` user agent.
- Full suite: 33 examples, 0 failures. RuboCop clean. Brakeman 8.0.6: 0 warnings.