### PR TITLE
fix: de-duplicate meeting time rows in reports csv

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -18,7 +18,10 @@ class ReportsController < ActionController::Base
     scope = Course::MeetingTime.joins(course: :term)
     scope = scope.where(terms: { uid: params[:term_uid] }) if params[:term_uid].present?
 
+    # DISTINCT: a concurrent-ingest race can leave identical meeting time rows
+    # (e.g. CRN 17294 in 202710 has 5 copies); the feed must not repeat them.
     rows = scope
+           .distinct
            .order(Arel.sql("terms.uid, courses.crn, course_meeting_times.day_of_week, course_meeting_times.begin_time"))
            .pluck(
              "terms.uid", "terms.season", "terms.year",

--- a/spec/requests/reports_spec.rb
+++ b/spec/requests/reports_spec.rb
@@ -80,6 +80,19 @@ RSpec.describe "Reports", type: :request do
       expect(csv.first["begin_time"]).to eq("13:50")
     end
 
+    it "collapses duplicate meeting time rows into one" do
+      fall_course.meeting_times.create!(
+        begin_time: 900, end_time: 1050, day_of_week: :monday,
+        meeting_schedule_type: :lecture, meeting_type: :class_meeting,
+        start_date: fall_course.start_date, end_date: fall_course.end_date
+      )
+
+      get "/reports/meeting_times", params: { term_uid: 202710 }
+
+      csv = CSV.parse(response.body, headers: true)
+      expect(csv.length).to eq(1)
+    end
+
     it "returns only headers when the term has no data" do
       get "/reports/meeting_times", params: { term_uid: 999999 }
 


### PR DESCRIPTION
## Problem

The `/reports/meeting_times` feed repeats identical rows. Example: CRN 17294 in term 202710 ships 5 identical rows (Monday 18:40–19:55, lecture). A concurrent-ingest race in `MeetingTimesIngestService` created 78 duplicate `course_meeting_times` rows across 20 courses. The per-run cache in the service does not protect against two runs that ingest the same course at the same time.

## Fix

Add `.distinct` to the report query. The feed now returns each meeting time once. All ORDER BY columns are in the SELECT list, so `SELECT DISTINCT` is valid.

This does not remove the duplicate rows from the database. A cleanup migration and a unique index are a follow-up.

## Test

New request spec: a second identical meeting time row collapses into one CSV row.